### PR TITLE
add CLI UI launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ renderkit convert-exr-sequence render.%04d.exr output.mp4 --burnin-frame --burni
 ### UI
 
 ```bash
-python -m renderkit.ui.main_window
+uv run renderkit ui
 ```
 
 ### Environment Variables

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ renderkit convert-exr-sequence render.%04d.exr output.mp4 --fps 24
 ### UI
 
 ```bash
-python -m renderkit.ui.main_window
+uv run renderkit ui
 ```
 
 ### Python API

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -105,7 +105,7 @@ processor.convert_with_config(config)
 Launch the UI from the terminal:
 
 ```bash
-python -m renderkit.ui.main_window
+uv run renderkit ui
 ```
 
 If you have a Pre-compiled build, run the exe in the `RenderKit/` folder.

--- a/src/renderkit/cli/main.py
+++ b/src/renderkit/cli/main.py
@@ -32,6 +32,25 @@ def main() -> None:
     pass
 
 
+def _launch_ui() -> None:
+    """Launch the RenderKit graphical interface."""
+    from renderkit.ui.main_window import run_ui
+
+    run_ui()
+
+
+@main.command(name="ui")
+def ui() -> None:
+    """Launch the RenderKit desktop UI."""
+    _launch_ui()
+
+
+@main.command(name="gui", hidden=True)
+def gui() -> None:
+    """Launch the RenderKit desktop UI."""
+    _launch_ui()
+
+
 @main.command()
 @click.argument("input_pattern", type=str)
 @click.argument("output_path", type=click.Path())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,54 @@
+"""Tests for the RenderKit command line interface."""
+
+from click.testing import CliRunner
+
+from renderkit.cli import main as cli_main
+
+
+def test_help_lists_ui_command(monkeypatch) -> None:
+    """Verify the public launcher appears in CLI help."""
+    monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
+    monkeypatch.setattr(cli_main, "setup_logging", lambda: None)
+
+    result = CliRunner().invoke(cli_main.main, ["--help"])
+
+    assert result.exit_code == 0
+    assert "ui" in result.output
+    assert "Launch the RenderKit desktop UI." in result.output
+    assert "gui" not in result.output
+
+
+def test_ui_command_launches_gui(monkeypatch) -> None:
+    """Verify the ui command dispatches to the Qt launcher."""
+    launched = False
+
+    def fake_launch_ui() -> None:
+        nonlocal launched
+        launched = True
+
+    monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
+    monkeypatch.setattr(cli_main, "setup_logging", lambda: None)
+    monkeypatch.setattr(cli_main, "_launch_ui", fake_launch_ui)
+
+    result = CliRunner().invoke(cli_main.main, ["ui"])
+
+    assert result.exit_code == 0
+    assert launched
+
+
+def test_gui_alias_launches_gui(monkeypatch) -> None:
+    """Verify the gui alias dispatches to the Qt launcher."""
+    launched = False
+
+    def fake_launch_ui() -> None:
+        nonlocal launched
+        launched = True
+
+    monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
+    monkeypatch.setattr(cli_main, "setup_logging", lambda: None)
+    monkeypatch.setattr(cli_main, "_launch_ui", fake_launch_ui)
+
+    result = CliRunner().invoke(cli_main.main, ["gui"])
+
+    assert result.exit_code == 0
+    assert launched


### PR DESCRIPTION
## Summary
- Add `renderkit ui` and `renderkit gui` to launch the desktop UI from the CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ui` CLI subcommand to launch the desktop interface with simplified command invocation.
  * Added hidden `gui` alias for the UI launcher.

* **Documentation**
  * Updated installation and usage guides with new UI launch instructions.

* **Tests**
  * Added comprehensive CLI command tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->