### PR TITLE
tighten runtime failure handling

### DIFF
--- a/src/renderkit/cli/main.py
+++ b/src/renderkit/cli/main.py
@@ -67,7 +67,7 @@ def main() -> None:
 )
 @click.option(
     "--quality",
-    type=int,
+    type=click.IntRange(0, 10),
     default=10,
     help="Video quality (0-10), 10 is best (default: 10). Sets CRF.",
 )
@@ -90,14 +90,19 @@ def main() -> None:
 @click.option("--burnin-fps", is_flag=True, default=False, help="Burn in frame rate (fps)")
 @click.option(
     "--burnin-opacity",
-    type=int,
+    type=click.IntRange(0, 100),
     default=30,
     help="Opacity of the burn-in background bar (0-100, default: 30)",
 )
 @click.option(
     "--contact-sheet", is_flag=True, default=False, help="Enable multi-AOV contact sheet mode"
 )
-@click.option("--cs-columns", type=int, default=4, help="Contact sheet columns (default: 4)")
+@click.option(
+    "--cs-columns",
+    type=click.IntRange(1),
+    default=4,
+    help="Contact sheet columns (default: 4)",
+)
 @click.option(
     "--cs-thumb-width",
     type=int,
@@ -217,20 +222,7 @@ def convert_exr_sequence(
     elif end_frame is not None:
         config_builder.with_frame_range(0, end_frame)
 
-    # Setup burn-ins
     burnin_elements = []
-    # Assume source width for positioning if output width not yet final in config_builder
-    # But wait, config_builder.width might be None.
-    # Let's use alignment logic instead.
-
-    # We'll need the actual width to position Center/Right correctly
-    # since OIIO render_text takes absolute coordinates.
-    # The converter will handle absolute positioning based on output_width.
-
-    # Actually, I'll update converter.py to handle relative positioning
-    # if I use special x values, or I'll just pass the intention.
-
-    # For now, let's just use standard padding and smaller font.
     font_size = 20
     if burnin_frame:
         burnin_elements.append(
@@ -239,9 +231,6 @@ def convert_exr_sequence(
             )
         )
     if burnin_layer:
-        # We can't know the exact center yet, so we'll fix this in converter.py
-        # to interpret -1 as center or something.
-        # Or better: update BurnInProcessor to handle 'left', 'center', 'right' specifically.
         burnin_elements.append(
             BurnInElement(
                 text_template="Layer: {layer}", x=0, y=10, font_size=font_size, alignment="center"

--- a/src/renderkit/core/config.py
+++ b/src/renderkit/core/config.py
@@ -44,6 +44,8 @@ class ContactSheetConfig:
 
     def __post_init__(self) -> None:
         """Validate configuration."""
+        if self.font_size <= 0:
+            raise ConfigurationError("Font size must be greater than 0")
         if self.columns <= 0:
             raise ConfigurationError("Columns must be greater than 0")
         if self.thumbnail_width is not None and self.thumbnail_width <= 0:
@@ -166,9 +168,17 @@ class ConversionConfig:
             raise ConfigurationError("Width must be greater than 0")
         if self.height is not None and self.height <= 0:
             raise ConfigurationError("Height must be greater than 0")
+        if self.bitrate is not None and self.bitrate <= 0:
+            raise ConfigurationError("Bitrate must be greater than 0")
+        if not 0 <= self.quality <= 10:
+            raise ConfigurationError("Quality must be between 0 and 10")
         if self.start_frame is not None and self.end_frame is not None:
             if self.start_frame > self.end_frame:
                 raise ConfigurationError("Start frame must be <= end frame")
+        if self.contact_sheet_mode and self.contact_sheet_config is None:
+            raise ConfigurationError(
+                "Contact sheet config is required when contact sheet mode is enabled"
+            )
 
 
 class ConversionConfigBuilder:

--- a/src/renderkit/core/converter.py
+++ b/src/renderkit/core/converter.py
@@ -190,7 +190,7 @@ class SequenceConverter:
         if hasattr(self.reader, "get_layer_map"):
             try:
                 self._layer_map = self.reader.get_layer_map(first_frame_path)
-            except Exception as e:
+            except ImageReadError as e:
                 logger.debug(f"Failed to build layer map for {first_frame_path}: {e}")
 
         if self.config.contact_sheet_mode and self.config.contact_sheet_config:
@@ -373,16 +373,10 @@ class SequenceConverter:
                         _tick_progress(i)
                         if frame_num in existing_frames:
                             future = prefetcher.get_future(frame_num)
-                            try:
-                                result = future.result()
-                            except Exception as e:
-                                logger.warning(f"Failed to process frame {frame_num}: {e}")
-                                result = None
-
-                            if result is not None:
-                                last_valid_buf = result
-                                self._write_frame_buf(frame_num, result)
-                                success_count += 1
+                            result = future.result()
+                            last_valid_buf = result
+                            self._write_frame_buf(frame_num, result)
+                            success_count += 1
                         else:
                             if self._write_freeze_frame(frame_num, last_valid_buf, i):
                                 success_count += 1
@@ -400,9 +394,8 @@ class SequenceConverter:
                             input_space,
                             self.contact_sheet_generator if contact_sheet_enabled else None,
                         )
-                        if result is not None:
-                            last_valid_buf = result
-                            success_count += 1
+                        last_valid_buf = result
+                        success_count += 1
                     else:
                         if self._write_freeze_frame(frame_num, last_valid_buf, i):
                             success_count += 1
@@ -441,29 +434,41 @@ class SequenceConverter:
         """Prepare a single frame buffer without writing it to the encoder."""
         frame_path = self.sequence.get_file_path(frame_num)
 
-        try:
-            if contact_sheet_generator:
+        if contact_sheet_generator:
+            try:
                 buf = contact_sheet_generator.composite_layers(frame_path)
-                spec = buf.spec()
-                width, height = spec.width, spec.height
-            else:
+            except ImageReadError as e:
+                raise ImageReadError(
+                    f"Failed to build contact sheet for frame {frame_num}: {e}"
+                ) from e
+            except (RuntimeError, TypeError, ValueError) as e:
+                raise VideoEncodingError(
+                    f"Failed to build contact sheet for frame {frame_num}: {e}"
+                ) from e
+            spec = buf.spec()
+            width, height = spec.width, spec.height
+        else:
+            try:
                 buf = reader.read_imagebuf(
                     frame_path,
                     layer=self.config.layer,
                     layer_map=self._layer_map,
                 )
-        except (ImageReadError, Exception) as e:
-            logger.warning(f"Failed to process frame {frame_num}: {e}")
-            return None
+            except ImageReadError as e:
+                raise ImageReadError(f"Failed to read frame {frame_num}: {e}") from e
 
         try:
             buf = color_converter.convert_buf(buf, input_space=input_space)
         except ColorSpaceError as e:
-            logger.warning(f"Color space conversion failed for frame {frame_num}: {e}")
-            return None
+            raise ColorSpaceError(
+                f"Color space conversion failed for frame {frame_num}: {e}"
+            ) from e
 
         if output_width != width or output_height != height:
-            buf = scaler.scale_buf(buf, output_width, output_height)
+            try:
+                buf = scaler.scale_buf(buf, output_width, output_height)
+            except (RuntimeError, TypeError, ValueError) as e:
+                raise VideoEncodingError(f"Failed to scale frame {frame_num}: {e}") from e
 
         if self.config.burnin_config and burnin_processor:
             try:
@@ -479,8 +484,10 @@ class SequenceConverter:
                     metadata,
                     self.config.burnin_config,
                 )
-            except Exception as e:
-                logger.error(f"Failed to apply burn-ins for frame {frame_num}: {e}")
+            except (RuntimeError, TypeError, ValueError) as e:
+                raise VideoEncodingError(
+                    f"Failed to apply burn-ins for frame {frame_num}: {e}"
+                ) from e
 
         return buf
 
@@ -505,7 +512,7 @@ class SequenceConverter:
             self.encoder.write_frame(buf)
         except VideoEncodingError:
             raise
-        except Exception as e:
+        except (RuntimeError, TypeError, ValueError) as e:
             logger.error(f"Failed to write {label} {frame_num}: {e}")
             raise VideoEncodingError(f"Failed to write {label} {frame_num}: {e}") from e
 
@@ -547,8 +554,6 @@ class SequenceConverter:
             self.burnin_processor,
             contact_sheet_generator=contact_sheet_generator,
         )
-        if buf is None:
-            return None
 
         self._write_frame_buf(frame_num, buf)
 

--- a/src/renderkit/io/image_reader.py
+++ b/src/renderkit/io/image_reader.py
@@ -289,7 +289,9 @@ class OIIOReader(ImageReader):
             logger.debug(f"Cached file info for {path}")
             return file_info
 
-        except Exception as e:
+        except ImageReadError:
+            raise
+        except (OSError, RuntimeError, TypeError, ValueError) as e:
             raise ImageReadError(f"Failed to read file info with OIIO: {path} - {e}") from e
 
     def get_layer_map(self, path: Path) -> dict[str, LayerMapEntry]:
@@ -340,7 +342,9 @@ class OIIOReader(ImageReader):
             self._layer_map_cache[cache_key] = layer_map
             return layer_map
 
-        except Exception as e:
+        except ImageReadError:
+            raise
+        except (OSError, RuntimeError, TypeError, ValueError) as e:
             raise ImageReadError(f"Failed to build layer map with OIIO: {path} - {e}") from e
 
     def read_imagebuf(
@@ -395,7 +399,9 @@ class OIIOReader(ImageReader):
 
             return buf
 
-        except Exception as e:
+        except ImageReadError:
+            raise
+        except (OSError, RuntimeError, TypeError, ValueError) as e:
             raise ImageReadError(f"Failed to read image with OIIO: {path} - {e}") from e
 
     def _resolve_subimage_for_layer(
@@ -434,7 +440,7 @@ class OIIOReader(ImageReader):
             if any(c.startswith(f"{layer}.") for c in spec.channelnames):
                 return i
 
-        return 0
+        raise ImageReadError(f"Layer '{layer}' was not found in {path}")
 
     def _slice_layer_from_buf(
         self,
@@ -478,9 +484,7 @@ class OIIOReader(ImageReader):
                 if buf.has_error:
                     raise ImageReadError(f"Failed to extract layer {layer}: {buf.geterror()}")
             elif subimage_index == 0 and not found_exact_match:
-                logger.warning(
-                    f"Layer {layer} not found in any part of {path}, falling back to beauty."
-                )
+                raise ImageReadError(f"Layer '{layer}' was not found in {path}")
 
         return buf
 
@@ -541,7 +545,9 @@ class OIIOReader(ImageReader):
 
             return buf
 
-        except Exception as e:
+        except ImageReadError:
+            raise
+        except (OSError, RuntimeError, TypeError, ValueError) as e:
             raise ImageReadError(
                 f"Failed to read subimage {subimage_index} with OIIO: {path} - {e}"
             ) from e
@@ -551,55 +557,36 @@ class OIIOReader(ImageReader):
 
         Uses cached file info to avoid redundant I/O.
         """
-        try:
-            file_info = self.get_file_info(path)
-            return file_info.layers
-        except ImageReadError:
-            return ["RGBA"]
+        return self.get_file_info(path).layers
 
     def get_channels(self, path: Path) -> int:
         """Get channel count using OIIO.
 
         Uses cached file info to avoid redundant I/O.
         """
-        try:
-            file_info = self.get_file_info(path)
-            return file_info.channels
-        except ImageReadError:
-            return 3
+        return self.get_file_info(path).channels
 
     def get_resolution(self, path: Path) -> tuple[int, int]:
         """Get resolution using OIIO.
 
         Uses cached file info to avoid redundant I/O.
         """
-        try:
-            file_info = self.get_file_info(path)
-            return (file_info.width, file_info.height)
-        except ImageReadError:
-            return (0, 0)
+        file_info = self.get_file_info(path)
+        return (file_info.width, file_info.height)
 
     def get_metadata_fps(self, path: Path) -> Optional[float]:
         """Get FPS from OIIO metadata.
 
         Uses cached file info to avoid redundant I/O.
         """
-        try:
-            file_info = self.get_file_info(path)
-            return file_info.fps
-        except ImageReadError:
-            return None
+        return self.get_file_info(path).fps
 
     def get_metadata_color_space(self, path: Path) -> Optional[str]:
         """Get color space from OIIO metadata.
 
         Uses cached file info to avoid redundant I/O.
         """
-        try:
-            file_info = self.get_file_info(path)
-            return file_info.color_space
-        except ImageReadError:
-            return None
+        return self.get_file_info(path).color_space
 
 
 class ImageReaderFactory:

--- a/src/renderkit/processing/burnin.py
+++ b/src/renderkit/processing/burnin.py
@@ -83,7 +83,9 @@ class BurnInProcessor:
                 textcolor=element.color,
                 alignx=element.alignment,
             ):
-                logger.error(f"Failed to render burn-in text '{text}': {self.oiio.geterror()}")
+                raise RuntimeError(
+                    f"Failed to render burn-in text '{text}': {self.oiio.geterror()}"
+                )
 
         return buf
 
@@ -100,8 +102,6 @@ class BurnInProcessor:
         try:
             return template.format(**metadata)
         except KeyError as e:
-            logger.warning(f"KeyError during token replacement: {e}")
-            return template
-        except Exception as e:
-            logger.error(f"Error during token replacement: {e}")
-            return template
+            raise ValueError(f"Missing burn-in metadata token: {e}") from e
+        except (IndexError, ValueError) as e:
+            raise ValueError(f"Invalid burn-in template '{template}': {e}") from e

--- a/src/renderkit/processing/contact_sheet.py
+++ b/src/renderkit/processing/contact_sheet.py
@@ -7,6 +7,7 @@ from typing import Optional
 import OpenImageIO as oiio
 
 from renderkit.core.config import ContactSheetConfig
+from renderkit.exceptions import ImageReadError
 from renderkit.io.image_reader import ImageReader, ImageReaderFactory, LayerMapEntry
 from renderkit.io.oiio_cache import get_shared_image_cache
 from renderkit.processing.scaler import ImageScaler
@@ -56,7 +57,7 @@ class ContactSheetGenerator:
             try:
                 layer_map = reader.get_layer_map(frame_path)
                 self.layer_map = layer_map
-            except Exception as e:
+            except ImageReadError as e:
                 logger.debug(f"Failed to precompute layer map for {frame_path}: {e}")
 
         if not layers:
@@ -91,7 +92,6 @@ class ContactSheetGenerator:
         canvas = oiio.ImageBuf(canvas_spec)
         oiio.ImageBufAlgo.fill(canvas, self.config.background_color)
 
-        # Process each layer
         for i, layer_name in enumerate(layers):
             row = i // cols
             col = i % cols
@@ -100,45 +100,50 @@ class ContactSheetGenerator:
             y_offset = row * cell_h + padding
 
             try:
-                if layer_name == layers[0]:
-                    layer_buf = first_buf
-                else:
-                    layer_buf = self._resolve_layer_buf(
+                layer_buf = (
+                    first_buf
+                    if layer_name == layers[0]
+                    else self._resolve_layer_buf(
                         reader,
                         frame_path,
                         layer_name,
                         layer_map,
                         subimage_buffers,
                     )
+                )
+            except ImageReadError as e:
+                raise ImageReadError(
+                    f"Failed to read layer '{layer_name}' for contact sheet: {e}"
+                ) from e
 
-                if layer_buf.spec().width == thumb_w and layer_buf.spec().height == thumb_h:
-                    scaled_buf = layer_buf
-                else:
-                    scaled_buf = self._scale_to_thumbnail(layer_buf, thumb_w, thumb_h)
+            if layer_buf.spec().width == thumb_w and layer_buf.spec().height == thumb_h:
+                scaled_buf = layer_buf
+            else:
+                scaled_buf = self._scale_to_thumbnail(layer_buf, thumb_w, thumb_h)
 
-                # Paste onto canvas
-                oiio.ImageBufAlgo.paste(canvas, x_offset, y_offset, 0, 0, scaled_buf)
+            if not oiio.ImageBufAlgo.paste(canvas, x_offset, y_offset, 0, 0, scaled_buf):
+                raise RuntimeError(
+                    f"Failed to paste layer '{layer_name}' into contact sheet: {oiio.geterror()}"
+                )
 
-                # Add label
-                if self.config.show_labels:
-                    label_x = x_offset
-                    label_y = (
-                        y_offset
-                        + thumb_h
-                        + label_gap
-                        + self.config.font_size
-                        - max(2, int(self.config.font_size * 0.2))
-                    )
-                    oiio.ImageBufAlgo.render_text(
-                        canvas,
-                        label_x,
-                        label_y,
-                        layer_name,
-                        fontsize=self.config.font_size,
-                        textcolor=(1, 1, 1, 1),
-                    )
-            except Exception as e:
-                logger.error(f"Failed to process layer {layer_name} for contact sheet: {e}")
+            if self.config.show_labels:
+                label_x = x_offset
+                label_y = (
+                    y_offset
+                    + thumb_h
+                    + label_gap
+                    + self.config.font_size
+                    - max(2, int(self.config.font_size * 0.2))
+                )
+                if not oiio.ImageBufAlgo.render_text(
+                    canvas,
+                    label_x,
+                    label_y,
+                    layer_name,
+                    fontsize=self.config.font_size,
+                    textcolor=(1, 1, 1, 1),
+                ):
+                    raise RuntimeError(f"Failed to render label '{layer_name}': {oiio.geterror()}")
 
         return canvas
 
@@ -200,7 +205,7 @@ class ContactSheetGenerator:
                     subimage_buffers[subimage_index] = oiio.ImageBuf(
                         str(frame_path), subimage_index, 0
                     )
-            except Exception as e:
+            except ImageReadError as e:
                 logger.debug(f"Failed to cache subimage {subimage_index} for {frame_path}: {e}")
                 return {}
 
@@ -220,12 +225,16 @@ class ContactSheetGenerator:
                 base_buf = subimage_buffers.get(entry.subimage_index)
                 if base_buf is not None:
                     if entry.channel_indices:
-                        try:
-                            return oiio.ImageBufAlgo.channels(base_buf, entry.channel_indices)
-                        except Exception as e:
+                        layer_buf = oiio.ImageBufAlgo.channels(base_buf, entry.channel_indices)
+                        if layer_buf.has_error:
                             logger.debug(
-                                f"Failed to slice channels for {layer_name} in {frame_path}: {e}"
+                                "Failed to slice channels for %s in %s: %s",
+                                layer_name,
+                                frame_path,
+                                layer_buf.geterror(),
                             )
+                        else:
+                            return layer_buf
                     else:
                         return base_buf
 

--- a/src/renderkit/ui/main_window_logic.py
+++ b/src/renderkit/ui/main_window_logic.py
@@ -213,6 +213,7 @@ class MainWindowLogicMixin:
 
     def _ensure_ocio_env(self) -> None:
         """Ensure OCIO environment variable is set, using bundled config if needed."""
+        bundled_config = None
         if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
             candidate = Path(sys._MEIPASS) / "renderkit" / "data" / "ocio" / "config.ocio"
             if candidate.exists():

--- a/tests/test_burnin.py
+++ b/tests/test_burnin.py
@@ -28,6 +28,13 @@ def test_token_replacement():
     assert result == expected
 
 
+def test_token_replacement_missing_token_raises():
+    processor = BurnInProcessor()
+
+    with pytest.raises(ValueError, match="Missing burn-in metadata token"):
+        processor._replace_tokens("Frame: {frame} | Shot: {shot}", {"frame": 101})
+
+
 def test_apply_burnins_logic():
     # This test verifies that the logic flows correctly.
     # Mocking OIIO might be complex, so we check if the processor handles empty configs gracefully.

--- a/tests/test_contact_sheet.py
+++ b/tests/test_contact_sheet.py
@@ -5,6 +5,7 @@ import pytest
 
 from renderkit.core.config import ContactSheetConfigBuilder
 from renderkit.core.ffmpeg_utils import get_ffmpeg_exe
+from renderkit.exceptions import ImageReadError
 from renderkit.io.image_reader import LayerMapEntry
 from renderkit.processing.contact_sheet import ContactSheetGenerator
 
@@ -169,3 +170,36 @@ def test_contact_sheet_uses_subimage_cache(tmp_path):
     assert composite is not None
     assert reader.image_calls == []
     assert set(reader.subimage_calls) == {0, 1}
+
+
+def test_contact_sheet_layer_failure_raises(tmp_path):
+    """Contact sheets should fail loudly when a requested layer cannot be read."""
+    try:
+        import OpenImageIO as oiio
+    except ImportError:
+        pytest.skip("OpenImageIO not available")
+
+    class FakeReader:
+        def get_layers(self, path):
+            return ["RGBA", "broken"]
+
+        def read_imagebuf(self, path, layer=None, layer_map=None):
+            if layer == "broken":
+                raise ImageReadError("missing layer")
+            spec = oiio.ImageSpec(16, 8, 3, oiio.FLOAT)
+            buf = oiio.ImageBuf(spec)
+            oiio.ImageBufAlgo.fill(buf, (0.2, 0.3, 0.4))
+            return buf
+
+    config = (
+        ContactSheetConfigBuilder()
+        .with_columns(2)
+        .with_thumbnail_width(16)
+        .with_labels(False)
+        .build()
+    )
+
+    generator = ContactSheetGenerator(config, reader=FakeReader())
+
+    with pytest.raises(ImageReadError, match="Failed to read layer 'broken'"):
+        generator.composite_layers(tmp_path / "dummy.exr")

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,9 +1,17 @@
 """Tests for converter (integration tests would require actual EXR files)."""
 
+from pathlib import Path
+
 import pytest
 
 from renderkit.core.config import ConversionConfig, ConversionConfigBuilder
-from renderkit.exceptions import ConfigurationError
+from renderkit.core.converter import SequenceConverter
+from renderkit.exceptions import (
+    ColorSpaceError,
+    ConfigurationError,
+    ImageReadError,
+    VideoEncodingError,
+)
 
 
 class TestConversionConfig:
@@ -47,6 +55,24 @@ class TestConversionConfig:
                 input_pattern="render.%04d.exr",
                 output_path="output.mp4",
                 prefetch_workers=0,
+            )
+
+    def test_config_validation_quality_range(self) -> None:
+        """Test quality validation."""
+        with pytest.raises(ConfigurationError):
+            ConversionConfig(
+                input_pattern="render.%04d.exr",
+                output_path="output.mp4",
+                quality=11,
+            )
+
+    def test_config_validation_contact_sheet_requires_config(self) -> None:
+        """Test contact sheet mode requires explicit layout configuration."""
+        with pytest.raises(ConfigurationError):
+            ConversionConfig(
+                input_pattern="render.%04d.exr",
+                output_path="output.mp4",
+                contact_sheet_mode=True,
             )
 
 
@@ -112,3 +138,111 @@ class TestConversionConfigBuilder:
         )
 
         assert config.prefetch_workers == 4
+
+
+class _FakeSequence:
+    def get_file_path(self, frame_num: int) -> Path:
+        return Path(f"render.{frame_num:04d}.exr")
+
+
+class _FakeBuf:
+    class _Spec:
+        width = 100
+        height = 100
+
+    def spec(self):
+        return self._Spec()
+
+
+class _PassThroughColorConverter:
+    def convert_buf(self, buf, input_space=None):
+        return buf
+
+
+class TestSequenceConverterFailures:
+    """Tests for strict frame failure behavior."""
+
+    def _converter(self) -> SequenceConverter:
+        converter = SequenceConverter.__new__(SequenceConverter)
+        converter.sequence = _FakeSequence()
+        converter.config = ConversionConfig(
+            input_pattern="render.%04d.exr",
+            output_path="output.mp4",
+            fps=24.0,
+        )
+        converter._layer_map = None
+        return converter
+
+    def test_prepare_frame_raises_on_read_failure(self) -> None:
+        """Existing-frame read failures should abort instead of returning None."""
+
+        class FailingReader:
+            def read_imagebuf(self, path, layer=None, layer_map=None):
+                raise ImageReadError("read failed")
+
+        converter = self._converter()
+
+        with pytest.raises(ImageReadError, match="Failed to read frame 1"):
+            converter._prepare_frame_buf(
+                1,
+                100,
+                100,
+                100,
+                100,
+                scaler=object(),
+                input_space=None,
+                reader=FailingReader(),
+                color_converter=_PassThroughColorConverter(),
+                burnin_processor=None,
+            )
+
+    def test_prepare_frame_raises_on_color_failure(self) -> None:
+        """Color conversion failures should abort instead of skipping frames."""
+
+        class Reader:
+            def read_imagebuf(self, path, layer=None, layer_map=None):
+                return _FakeBuf()
+
+        class FailingColorConverter:
+            def convert_buf(self, buf, input_space=None):
+                raise ColorSpaceError("bad transform")
+
+        converter = self._converter()
+
+        with pytest.raises(ColorSpaceError, match="Color space conversion failed for frame 2"):
+            converter._prepare_frame_buf(
+                2,
+                100,
+                100,
+                100,
+                100,
+                scaler=object(),
+                input_space=None,
+                reader=Reader(),
+                color_converter=FailingColorConverter(),
+                burnin_processor=None,
+            )
+
+    def test_prepare_frame_wraps_contact_sheet_render_failure(self) -> None:
+        """Contact sheet render failures should include frame context."""
+
+        class FailingContactSheetGenerator:
+            def composite_layers(self, path):
+                raise RuntimeError("label render failed")
+
+        converter = self._converter()
+
+        with pytest.raises(VideoEncodingError, match="Failed to build contact sheet for frame 3"):
+            converter._prepare_frame_buf(
+                3,
+                100,
+                100,
+                100,
+                100,
+                scaler=object(),
+                input_space=None,
+                reader=object(),
+                color_converter=_PassThroughColorConverter(),
+                burnin_processor=None,
+                contact_sheet_generator=FailingContactSheetGenerator(),
+            )


### PR DESCRIPTION
## What changed

- Tightened runtime failure handling so frame read, contact-sheet, color conversion, scaling, burn-in, and encode failures propagate with explicit context instead of being silently skipped.
- Removed permissive image metadata/layer fallbacks and made missing requested layers fail with `ImageReadError`.
- Added stricter config and CLI validation for quality, bitrate, contact-sheet config, font size, opacity, and columns.
- Added regression tests for strict read/color/contact-sheet/burn-in failure behavior.

## Why

The app previously tolerated too many partial-success paths, which could hide broken renders behind skipped frames, default image metadata, or incomplete contact sheets. This makes failures easier to diagnose and safer to trust.

## Validation

- `uv --native-tls run ruff check`
- `uv --native-tls run ruff format --check`
- `uv --native-tls run --extra dev pytest` (`80 passed, 8 skipped`)
