### PR TITLE
Scale preview burn-ins with preview image

### DIFF
--- a/src/renderkit/ui/widgets.py
+++ b/src/renderkit/ui/widgets.py
@@ -1,13 +1,14 @@
 """Custom widgets for the UI."""
 
 import logging
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, Optional
 
 import numpy as np
 import OpenImageIO as oiio
 
-from renderkit.core.config import BurnInConfig, ContactSheetConfig
+from renderkit.core.config import BurnInConfig, BurnInElement, ContactSheetConfig
 from renderkit.exceptions import RenderKitError
 from renderkit.io.image_reader import ImageReaderFactory
 from renderkit.io.oiio_cache import get_shared_image_cache
@@ -33,6 +34,40 @@ from renderkit.ui.qt_compat import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _scaled_burnin_config_for_preview(
+    burnin_config: BurnInConfig,
+    scale: float,
+    image_width: int,
+) -> BurnInConfig:
+    """Return a burn-in config scaled to match a reduced preview image."""
+    if scale >= 1.0:
+        return burnin_config
+
+    auto_margin = max(1, int(round(20 * scale)))
+    scaled_elements: list[BurnInElement] = []
+
+    for element in burnin_config.elements:
+        x_pos = int(round(element.x * scale))
+        if element.x == 0:
+            if element.alignment == "center":
+                x_pos = image_width // 2
+            elif element.alignment == "right":
+                x_pos = max(1, image_width - auto_margin)
+            elif element.alignment == "left":
+                x_pos = auto_margin
+
+        scaled_elements.append(
+            replace(
+                element,
+                x=x_pos,
+                y=max(0, int(round(element.y * scale))),
+                font_size=max(1, int(round(element.font_size * scale))),
+            )
+        )
+
+    return replace(burnin_config, elements=scaled_elements)
 
 
 class PreviewWorker(QThread):
@@ -87,6 +122,8 @@ class PreviewWorker(QThread):
                 )
                 buf = reader.read_imagebuf(self.file_path, layer=self.layer)
 
+            applied_preview_scale = 1.0
+
             # Apply preview scale
             if self.preview_scale < 1.0:
                 spec = buf.spec()
@@ -96,6 +133,11 @@ class PreviewWorker(QThread):
                 from renderkit.processing.scaler import ImageScaler
 
                 buf = ImageScaler.scale_buf(buf, width=new_w, height=new_h)
+                scaled_spec = buf.spec()
+                applied_preview_scale = min(
+                    scaled_spec.width / float(w),
+                    scaled_spec.height / float(h),
+                )
 
             # Convert color space
             converter = ColorSpaceConverter(self.color_space)
@@ -105,10 +147,15 @@ class PreviewWorker(QThread):
                 from renderkit.processing.burnin import BurnInProcessor
 
                 processor = BurnInProcessor()
+                burnin_config = _scaled_burnin_config_for_preview(
+                    self.burnin_config,
+                    applied_preview_scale,
+                    buf.spec().width,
+                )
                 buf = processor.apply_burnins(
                     buf,
                     self.burnin_metadata,
-                    self.burnin_config,
+                    burnin_config,
                 )
 
             image = buf.get_pixels(oiio.FLOAT)

--- a/tests/test_ui_widgets.py
+++ b/tests/test_ui_widgets.py
@@ -1,0 +1,41 @@
+"""Tests for shared UI widget helpers."""
+
+from renderkit.core.config import BurnInConfig, BurnInElement
+from renderkit.ui.widgets import _scaled_burnin_config_for_preview
+
+
+def test_scaled_burnin_config_for_preview_scales_font_and_positions() -> None:
+    """Preview burn-ins should stay proportional to reduced preview buffers."""
+    config = BurnInConfig(
+        elements=[
+            BurnInElement("Frame: {frame}", x=0, y=10, font_size=20, alignment="left"),
+            BurnInElement("Layer: {layer}", x=0, y=10, font_size=20, alignment="center"),
+            BurnInElement("FPS: {fps}", x=0, y=10, font_size=20, alignment="right"),
+            BurnInElement("Shot", x=100, y=40, font_size=24, alignment="left"),
+        ],
+        background_opacity=45,
+    )
+
+    scaled = _scaled_burnin_config_for_preview(config, scale=0.25, image_width=480)
+
+    assert scaled is not config
+    assert scaled.background_opacity == 45
+    assert [element.font_size for element in scaled.elements] == [5, 5, 5, 6]
+    assert [(element.x, element.y) for element in scaled.elements] == [
+        (5, 2),
+        (240, 2),
+        (475, 2),
+        (25, 10),
+    ]
+
+
+def test_scaled_burnin_config_for_preview_does_not_mutate_original() -> None:
+    """Preview scaling should not change final-render burn-in settings."""
+    original = BurnInElement("Frame: {frame}", x=0, y=10, font_size=20, alignment="left")
+    config = BurnInConfig(elements=[original])
+
+    _scaled_burnin_config_for_preview(config, scale=0.5, image_width=960)
+
+    assert original.x == 0
+    assert original.y == 10
+    assert original.font_size == 20


### PR DESCRIPTION
## Summary
- Scale preview burn-in font sizes and coordinates with the preview image buffer.
- Keep final-render burn-in settings unchanged by using a copied preview-only config.
- Add focused tests for proportional preview scaling and mutation safety.

## Validation
- uv --native-tls run --extra dev ruff check .
- uv --native-tls run --extra dev pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview images with burn-in overlays now correctly scale element positioning and font sizes based on preview dimensions, ensuring accurate visual representation across different scales.

* **Tests**
  * Added comprehensive tests validating burn-in overlay scaling behavior and configuration immutability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->