### PR TITLE
fix: add hover highlighting to combo box dropdown items

### DIFF
--- a/src/renderkit/ui/main_window_widgets.py
+++ b/src/renderkit/ui/main_window_widgets.py
@@ -2,7 +2,10 @@
 
 from renderkit.ui.qt_compat import (
     QComboBox,
+    QCursor,
     QDoubleSpinBox,
+    QEvent,
+    QListView,
     QObject,
     QSizePolicy,
     QSlider,
@@ -10,8 +13,36 @@ from renderkit.ui.qt_compat import (
     QStyle,
     QStyleOptionSlider,
     Qt,
+    QTimer,
     Signal,
 )
+
+COMBO_POPUP_OBJECT_NAME = "ComboBoxPopup"
+COMBO_POPUP_STYLESHEET = """
+QListView,
+QAbstractItemView {
+    background-color: #0d1117;
+    color: #e6edf3;
+    selection-background-color: #4493f8;
+    selection-color: #e6edf3;
+    border: 1px solid #30363db3;
+}
+
+QListView::item,
+QAbstractItemView::item {
+    padding: 4px 8px;
+}
+
+QListView::item:selected,
+QAbstractItemView::item:selected {
+    background-color: #4493f8;
+    color: #e6edf3;
+}
+"""
+try:
+    MOUSE_MOVE_EVENT = QEvent.Type.MouseMove
+except AttributeError:
+    MOUSE_MOVE_EVENT = QEvent.MouseMove
 
 
 class NoWheelSpinBox(QSpinBox):
@@ -48,14 +79,65 @@ class NoWheelDoubleSpinBox(QDoubleSpinBox):
         super().wheelEvent(event)
 
 
+class ComboPopupView(QListView):
+    """List view that keeps combo popup highlight under the cursor."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._hover_timer = QTimer(self)
+        self._hover_timer.setInterval(16)
+        self._hover_timer.timeout.connect(self._highlight_index_under_cursor)
+
+    def start_hover_tracking(self) -> None:
+        self._highlight_index_under_cursor()
+        self._hover_timer.start()
+
+    def stop_hover_tracking(self) -> None:
+        self._hover_timer.stop()
+
+    def showEvent(self, event) -> None:
+        super().showEvent(event)
+        self.start_hover_tracking()
+
+    def hideEvent(self, event) -> None:
+        self.stop_hover_tracking()
+        super().hideEvent(event)
+
+    def viewportEvent(self, event: QEvent) -> bool:
+        if event.type() == MOUSE_MOVE_EVENT:
+            self._highlight_index_at_event(event)
+        return super().viewportEvent(event)
+
+    def mouseMoveEvent(self, event) -> None:
+        self._highlight_index_at_event(event)
+        super().mouseMoveEvent(event)
+
+    def _highlight_index_at_event(self, event) -> None:
+        position = event.position().toPoint() if hasattr(event, "position") else event.pos()
+        index = self.indexAt(position)
+        if index.isValid():
+            self.setCurrentIndex(index)
+
+    def _highlight_index_under_cursor(self) -> None:
+        viewport = self.viewport()
+        position = viewport.mapFromGlobal(QCursor.pos())
+        if not viewport.rect().contains(position):
+            return
+        index = self.indexAt(position)
+        if index.isValid():
+            self.setCurrentIndex(index)
+
+
 class NoWheelComboBox(QComboBox):
     """Combo box that ignores wheel events unless focused."""
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        self.setView(ComboPopupView(self))
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.setMinimumWidth(0)
+        self._configure_popup_view()
         size_adjust_policy = getattr(QComboBox, "SizeAdjustPolicy", None)
         if size_adjust_policy is not None:
             self.setSizeAdjustPolicy(size_adjust_policy.AdjustToMinimumContentsLengthWithIcon)
@@ -66,11 +148,32 @@ class NoWheelComboBox(QComboBox):
         if line_edit is not None:
             line_edit.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
+    def _configure_popup_view(self) -> None:
+        view = self.view()
+        view.setObjectName(COMBO_POPUP_OBJECT_NAME)
+        view.setMouseTracking(True)
+        view.setStyleSheet(COMBO_POPUP_STYLESHEET)
+        viewport = view.viewport()
+        if viewport is not None:
+            viewport.setMouseTracking(True)
+
     def wheelEvent(self, event) -> None:
         if not self.hasFocus():
             event.ignore()
             return
         super().wheelEvent(event)
+
+    def showPopup(self) -> None:
+        super().showPopup()
+        view = self.view()
+        if isinstance(view, ComboPopupView):
+            view.start_hover_tracking()
+
+    def hidePopup(self) -> None:
+        view = self.view()
+        if isinstance(view, ComboPopupView):
+            view.stop_hover_tracking()
+        super().hidePopup()
 
 
 class NoWheelSlider(QSlider):

--- a/src/renderkit/ui/qt_compat.py
+++ b/src/renderkit/ui/qt_compat.py
@@ -25,6 +25,7 @@ _QTCORE_NAMES = [
 ]
 _QTGUI_NAMES = [
     "QColor",
+    "QCursor",
     "QDesktopServices",
     "QFont",
     "QIcon",
@@ -46,6 +47,7 @@ _QTWIDGET_NAMES = [
     "QHBoxLayout",
     "QLabel",
     "QLineEdit",
+    "QListView",
     "QMainWindow",
     "QMessageBox",
     "QPlainTextEdit",
@@ -80,6 +82,7 @@ if TYPE_CHECKING:
     )
     from PySide6.QtGui import (  # noqa: F401
         QColor,
+        QCursor,
         QDesktopServices,
         QFont,
         QIcon,
@@ -101,6 +104,7 @@ if TYPE_CHECKING:
         QHBoxLayout,
         QLabel,
         QLineEdit,
+        QListView,
         QMainWindow,
         QMessageBox,
         QPlainTextEdit,
@@ -189,6 +193,7 @@ __all__ = [
     "QImage",
     "QDesktopServices",
     "QColor",
+    "QCursor",
     "QPainter",
     "QPalette",
     # Qt Widgets
@@ -203,6 +208,7 @@ __all__ = [
     "QHBoxLayout",
     "QLabel",
     "QLineEdit",
+    "QListView",
     "QMainWindow",
     "QMessageBox",
     "QPlainTextEdit",

--- a/src/renderkit/ui/stylesheets/matcha.qss
+++ b/src/renderkit/ui/stylesheets/matcha.qss
@@ -216,6 +216,10 @@ QProgressBar {
     border-color: #0969da;
 }
 
+[theme="light"] QComboBox:hover {
+    background-color: #f6f8fa;
+}
+
 [theme="light"] QLineEdit:focus, [theme="light"] QTextEdit:focus, [theme="light"] QComboBox:focus,
 [theme="light"] QPlainTextEdit:focus, [theme="light"] QSpinBox:focus, [theme="light"] QDoubleSpinBox:focus {
     border-color: #8250df;
@@ -242,6 +246,16 @@ QProgressBar {
     selection-background-color: #0969da;
     selection-color: #e6edf3;
     border: 1px solid #d0d7deb3;
+}
+
+[theme="light"] QComboBox QAbstractItemView::item {
+    padding: 4px 8px;
+}
+
+[theme="light"] QComboBox QAbstractItemView::item:hover,
+[theme="light"] QComboBox QAbstractItemView::item:selected {
+    background-color: #0969da;
+    color: #e6edf3;
 }
 
 [theme="light"] QCheckBox:disabled, [theme="light"] QRadioButton:disabled, [theme="light"] QSlider:disabled {
@@ -399,6 +413,10 @@ QProgressBar {
     border-color: #4493f8;
 }
 
+[theme="dark"] QComboBox:hover {
+    background-color: #161b22;
+}
+
 [theme="dark"] QLineEdit:focus, [theme="dark"] QTextEdit:focus, [theme="dark"] QComboBox:focus,
 [theme="dark"] QPlainTextEdit:focus, [theme="dark"] QSpinBox:focus, [theme="dark"] QDoubleSpinBox:focus {
     border-color: #a371f7;
@@ -425,6 +443,39 @@ QProgressBar {
     selection-background-color: #4493f8;
     selection-color: #e6edf3;
     border: 1px solid #30363db3;
+}
+
+/* QComboBox popups are separate item views, so target the popup view directly. */
+QListView#ComboBoxPopup,
+QAbstractItemView#ComboBoxPopup {
+    background-color: #0d1117;
+    color: #e6edf3;
+    selection-background-color: #4493f8;
+    selection-color: #e6edf3;
+    border: 1px solid #30363db3;
+}
+
+[theme="dark"] QComboBox QAbstractItemView::item {
+    padding: 4px 8px;
+}
+
+QListView#ComboBoxPopup::item,
+QAbstractItemView#ComboBoxPopup::item {
+    padding: 4px 8px;
+}
+
+[theme="dark"] QComboBox QAbstractItemView::item:hover,
+[theme="dark"] QComboBox QAbstractItemView::item:selected {
+    background-color: #4493f8;
+    color: #e6edf3;
+}
+
+QListView#ComboBoxPopup::item:hover,
+QListView#ComboBoxPopup::item:selected,
+QAbstractItemView#ComboBoxPopup::item:hover,
+QAbstractItemView#ComboBoxPopup::item:selected {
+    background-color: #4493f8;
+    color: #e6edf3;
 }
 
 [theme="dark"] QCheckBox:disabled, [theme="dark"] QRadioButton:disabled, [theme="dark"] QSlider:disabled {

--- a/tests/test_ui_stylesheet.py
+++ b/tests/test_ui_stylesheet.py
@@ -1,0 +1,27 @@
+"""Tests for UI stylesheet expectations."""
+
+from importlib import resources
+
+
+def _active_theme_qss() -> str:
+    return (
+        resources.files("renderkit.ui")
+        .joinpath("stylesheets", "matcha.qss")
+        .read_text(encoding="utf-8")
+    )
+
+
+def test_combo_boxes_have_hover_highlights() -> None:
+    """Ensure dropdown widgets visibly respond to hover in the active theme."""
+    qss = _active_theme_qss()
+
+    assert '[theme="light"] QComboBox:hover' in qss
+    assert "background-color: #f6f8fa;" in qss
+    assert '[theme="dark"] QComboBox:hover' in qss
+    assert "background-color: #161b22;" in qss
+    assert '[theme="light"] QComboBox QAbstractItemView::item:hover' in qss
+    assert "background-color: #0969da;" in qss
+    assert '[theme="dark"] QComboBox QAbstractItemView::item:hover' in qss
+    assert "QListView#ComboBoxPopup::item:hover" in qss
+    assert "QAbstractItemView#ComboBoxPopup::item:hover" in qss
+    assert "background-color: #4493f8;" in qss

--- a/tests/test_ui_widgets.py
+++ b/tests/test_ui_widgets.py
@@ -1,6 +1,9 @@
 """Tests for shared UI widget helpers."""
 
+import pytest
+
 from renderkit.core.config import BurnInConfig, BurnInElement
+from renderkit.ui.qt_compat import QApplication
 from renderkit.ui.widgets import _scaled_burnin_config_for_preview
 
 
@@ -39,3 +42,52 @@ def test_scaled_burnin_config_for_preview_does_not_mutate_original() -> None:
     assert original.x == 0
     assert original.y == 10
     assert original.font_size == 20
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    """Create QApplication for tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+    app.quit()
+
+
+def test_no_wheel_combo_popup_tracks_hover(qtbot, qapp) -> None:
+    """Ensure combo popup rows can receive hover styling."""
+    from renderkit.ui.main_window_widgets import (
+        COMBO_POPUP_OBJECT_NAME,
+        COMBO_POPUP_STYLESHEET,
+        NoWheelComboBox,
+    )
+
+    combo = NoWheelComboBox()
+    qtbot.addWidget(combo)
+
+    view = combo.view()
+    assert view.objectName() == COMBO_POPUP_OBJECT_NAME
+    assert view.hasMouseTracking() is True
+    assert view.viewport().hasMouseTracking() is True
+    assert view.styleSheet() == COMBO_POPUP_STYLESHEET
+
+
+def test_no_wheel_combo_popup_hover_updates_current_row(qtbot, qapp) -> None:
+    """Ensure hovering a popup item moves the highlighted row."""
+    from renderkit.ui.main_window_widgets import NoWheelComboBox
+    from renderkit.ui.qt_compat import QCursor
+
+    combo = NoWheelComboBox()
+    combo.addItems(["first", "second", "third"])
+    qtbot.addWidget(combo)
+    combo.show()
+    combo.showPopup()
+    qtbot.wait(10)
+
+    view = combo.view()
+    target = view.model().index(1, 0)
+    target_position = view.visualRect(target).center()
+    QCursor.setPos(view.viewport().mapToGlobal(target_position))
+
+    qtbot.waitUntil(lambda: view.currentIndex().row() == 1, timeout=1000)
+    combo.hidePopup()


### PR DESCRIPTION
## Summary
- Added `QSS :hover` and `:selected` rules to `matcha.qss` for both light and dark themes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Combo box popup items now highlight when hovered, providing instant visual feedback on selection.

* **Style**
  * Enhanced combo box hover and popup styling for improved visual feedback in both light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->