### PR TITLE
Scope combo popup dark theme styles

### DIFF
--- a/src/renderkit/ui/stylesheets/matcha.qss
+++ b/src/renderkit/ui/stylesheets/matcha.qss
@@ -446,8 +446,8 @@ QProgressBar {
 }
 
 /* QComboBox popups are separate item views, so target the popup view directly. */
-QListView#ComboBoxPopup,
-QAbstractItemView#ComboBoxPopup {
+[theme="dark"] QListView#ComboBoxPopup,
+[theme="dark"] QAbstractItemView#ComboBoxPopup {
     background-color: #0d1117;
     color: #e6edf3;
     selection-background-color: #4493f8;
@@ -459,8 +459,8 @@ QAbstractItemView#ComboBoxPopup {
     padding: 4px 8px;
 }
 
-QListView#ComboBoxPopup::item,
-QAbstractItemView#ComboBoxPopup::item {
+[theme="dark"] QListView#ComboBoxPopup::item,
+[theme="dark"] QAbstractItemView#ComboBoxPopup::item {
     padding: 4px 8px;
 }
 
@@ -470,10 +470,10 @@ QAbstractItemView#ComboBoxPopup::item {
     color: #e6edf3;
 }
 
-QListView#ComboBoxPopup::item:hover,
-QListView#ComboBoxPopup::item:selected,
-QAbstractItemView#ComboBoxPopup::item:hover,
-QAbstractItemView#ComboBoxPopup::item:selected {
+[theme="dark"] QListView#ComboBoxPopup::item:hover,
+[theme="dark"] QListView#ComboBoxPopup::item:selected,
+[theme="dark"] QAbstractItemView#ComboBoxPopup::item:hover,
+[theme="dark"] QAbstractItemView#ComboBoxPopup::item:selected {
     background-color: #4493f8;
     color: #e6edf3;
 }

--- a/tests/test_ui_stylesheet.py
+++ b/tests/test_ui_stylesheet.py
@@ -22,6 +22,11 @@ def test_combo_boxes_have_hover_highlights() -> None:
     assert '[theme="light"] QComboBox QAbstractItemView::item:hover' in qss
     assert "background-color: #0969da;" in qss
     assert '[theme="dark"] QComboBox QAbstractItemView::item:hover' in qss
-    assert "QListView#ComboBoxPopup::item:hover" in qss
-    assert "QAbstractItemView#ComboBoxPopup::item:hover" in qss
+    assert '[theme="dark"] QListView#ComboBoxPopup::item:hover' in qss
+    assert '[theme="dark"] QAbstractItemView#ComboBoxPopup::item:hover' in qss
     assert "background-color: #4493f8;" in qss
+
+    for line in qss.splitlines():
+        stripped_line = line.strip().rstrip(",")
+        if "ComboBoxPopup" in stripped_line:
+            assert stripped_line.startswith('[theme="dark"] ')


### PR DESCRIPTION
## Summary
- Scope ComboBox popup object-name selectors to [theme=dark].
