### PR TITLE
Centralize Qt test fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Shared pytest fixtures for RenderKit tests."""
+
+import pytest
+
+from renderkit.ui.qt_compat import QApplication
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    """Create a QApplication for Qt widget tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+    app.quit()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -6,11 +6,7 @@ Run with: pytest tests/test_ui.py -v
 
 from pathlib import Path
 
-import pytest
-
-# Skip UI tests if pytest-qt is not available
 from renderkit.ui.qt_compat import (
-    QApplication,
     get_qt_backend,
 )
 
@@ -60,16 +56,6 @@ def test_frame_range_updates(qtbot, tmp_path, monkeypatch):
     qtbot.waitUntil(lambda: window.start_frame_spin.value() == 1, timeout=1000)
     assert window.start_frame_spin.value() == 1
     assert window.end_frame_spin.value() == 5
-
-
-@pytest.fixture(scope="session")
-def qapp():
-    """Create QApplication for tests."""
-    app = QApplication.instance()
-    if app is None:
-        app = QApplication([])
-    yield app
-    app.quit()
 
 
 def test_qt_backend_detection():

--- a/tests/test_ui_splash.py
+++ b/tests/test_ui_splash.py
@@ -1,23 +1,10 @@
 """Tests for splash screen rendering and timing helpers."""
 
-import pytest
-
-from renderkit.ui.qt_compat import QApplication
 from renderkit.ui.splash_screen import (
     SPLASH_MIN_DURATION_MS,
     compute_remaining_splash_ms,
     create_splash_screen,
 )
-
-
-@pytest.fixture(scope="session")
-def qapp():
-    """Create QApplication for Qt widget tests."""
-    app = QApplication.instance()
-    if app is None:
-        app = QApplication([])
-    yield app
-    app.quit()
 
 
 def test_compute_remaining_splash_ms_partial_elapsed():

--- a/tests/test_ui_toggles.py
+++ b/tests/test_ui_toggles.py
@@ -1,19 +1,5 @@
 """Tests for the UI toggles in ModernMainWindow."""
 
-import pytest
-
-from renderkit.ui.qt_compat import QApplication
-
-
-@pytest.fixture(scope="session")
-def qapp():
-    """Create QApplication for tests."""
-    app = QApplication.instance()
-    if app is None:
-        app = QApplication([])
-    yield app
-    app.quit()
-
 
 def test_burnin_toggle(qtbot, qapp):
     """Test that burn-in toggle correctly enables/disables child widgets."""

--- a/tests/test_ui_widgets.py
+++ b/tests/test_ui_widgets.py
@@ -1,9 +1,6 @@
 """Tests for shared UI widget helpers."""
 
-import pytest
-
 from renderkit.core.config import BurnInConfig, BurnInElement
-from renderkit.ui.qt_compat import QApplication
 from renderkit.ui.widgets import _scaled_burnin_config_for_preview
 
 
@@ -42,16 +39,6 @@ def test_scaled_burnin_config_for_preview_does_not_mutate_original() -> None:
     assert original.x == 0
     assert original.y == 10
     assert original.font_size == 20
-
-
-@pytest.fixture(scope="session")
-def qapp():
-    """Create QApplication for tests."""
-    app = QApplication.instance()
-    if app is None:
-        app = QApplication([])
-    yield app
-    app.quit()
 
 
 def test_no_wheel_combo_popup_tracks_hover(qtbot, qapp) -> None:


### PR DESCRIPTION
## Summary
- Move the shared Qt `qapp` pytest fixture into `tests/conftest.py`.
