### PR TITLE
Fix data AOV preview display

### DIFF
--- a/src/renderkit/ui/widgets.py
+++ b/src/renderkit/ui/widgets.py
@@ -71,6 +71,28 @@ def _scaled_burnin_config_for_preview(
     return replace(burnin_config, elements=scaled_elements)
 
 
+def _prepare_buf_for_preview_display(
+    buf: oiio.ImageBuf,
+    color_space: ColorSpacePreset,
+    input_space: Optional[str],
+) -> oiio.ImageBuf:
+    """Return an RGB/RGBA preview buffer that Qt can display."""
+    spec = buf.spec()
+
+    if spec.nchannels not in (3, 4):
+        logger.debug(
+            "Skipping color conversion for non-RGB preview buffer. channels=%s",
+            spec.nchannels,
+        )
+        display_buf = oiio.ImageBufAlgo.channels(buf, (0, 0, 0), ("R", "G", "B"))
+        if display_buf.has_error:
+            raise ValueError(f"Failed to prepare data-channel preview: {display_buf.geterror()}")
+        return display_buf
+
+    converter = ColorSpaceConverter(color_space)
+    return converter.convert_buf(buf, input_space=input_space)
+
+
 class PreviewWorker(QThread):
     """Worker thread for loading preview image."""
 
@@ -140,9 +162,11 @@ class PreviewWorker(QThread):
                     scaled_spec.height / float(h),
                 )
 
-            # Convert color space
-            converter = ColorSpaceConverter(self.color_space)
-            buf = converter.convert_buf(buf, input_space=self.input_space)
+            buf = _prepare_buf_for_preview_display(
+                buf,
+                self.color_space,
+                self.input_space,
+            )
 
             if self.burnin_config and self.burnin_metadata:
                 from renderkit.processing.burnin import BurnInProcessor

--- a/tests/test_ui_widgets.py
+++ b/tests/test_ui_widgets.py
@@ -1,7 +1,16 @@
 """Tests for shared UI widget helpers."""
 
+import numpy as np
+import pytest
+
 from renderkit.core.config import BurnInConfig, BurnInElement
-from renderkit.ui.widgets import _scaled_burnin_config_for_preview
+from renderkit.processing.color_space import ColorSpacePreset
+from renderkit.ui.widgets import _prepare_buf_for_preview_display, _scaled_burnin_config_for_preview
+
+try:
+    import OpenImageIO as oiio
+except ImportError:
+    oiio = None
 
 
 def test_scaled_burnin_config_for_preview_scales_font_and_positions() -> None:
@@ -39,6 +48,37 @@ def test_scaled_burnin_config_for_preview_does_not_mutate_original() -> None:
     assert original.x == 0
     assert original.y == 10
     assert original.font_size == 20
+
+
+@pytest.mark.parametrize("channels", [1, 2])
+def test_prepare_buf_for_preview_display_expands_data_channels(channels: int) -> None:
+    """Data-channel AOV previews should display as grayscale RGB without OCIO."""
+    if oiio is None:
+        pytest.skip("OpenImageIO not available")
+
+    pixels = np.array(
+        [
+            [[0.1, 0.8], [0.2, 0.7]],
+            [[0.3, 0.6], [0.4, 0.5]],
+        ],
+        dtype=np.float32,
+    )[:, :, :channels]
+    spec = oiio.ImageSpec(2, 2, channels, oiio.FLOAT)
+    buf = oiio.ImageBuf(spec)
+    assert buf.set_pixels(oiio.ROI(), pixels)
+
+    result = _prepare_buf_for_preview_display(
+        buf,
+        ColorSpacePreset.OCIO_CONVERSION,
+        input_space="rendering",
+    )
+
+    result_spec = result.spec()
+    assert result_spec.nchannels == 3
+    result_pixels = result.get_pixels(oiio.FLOAT)
+    np.testing.assert_allclose(result_pixels[:, :, 0], pixels[:, :, 0])
+    np.testing.assert_allclose(result_pixels[:, :, 1], pixels[:, :, 0])
+    np.testing.assert_allclose(result_pixels[:, :, 2], pixels[:, :, 0])
 
 
 def test_no_wheel_combo_popup_tracks_hover(qtbot, qapp) -> None:


### PR DESCRIPTION
## Summary
- skip OCIO conversion for non-RGB/RGBA preview buffers so data AOVs like depth do not hit RGB-only color conversion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of image buffer previews for non-standard channel formats and color-space conversion.
  * Enhanced preview preparation to properly expand single and multi-channel data for display.

* **Tests**
  * Added parametrized tests for data-channel AOV preview functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->