### PR TITLE
Fix printf frame pattern resolution

### DIFF
--- a/src/renderkit/core/sequence.py
+++ b/src/renderkit/core/sequence.py
@@ -41,7 +41,11 @@ class FrameSequence:
         """
         # Replace common patterns with the actual frame number
         frame_str = str(frame_number).zfill(self.padding)
-        file_path = self.pattern.replace("%04d", frame_str)
+        file_path = re.sub(
+            r"%0?(\d+)d",
+            lambda m: str(frame_number).zfill(int(m.group(1))),
+            self.pattern,
+        )
         file_path = file_path.replace("$F4", frame_str)
         file_path = re.sub(r"#+", lambda m: frame_str.zfill(len(m.group())), file_path)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,11 @@
 """Tests for the RenderKit command line interface."""
 
+from pathlib import Path
+
 from click.testing import CliRunner
 
 from renderkit.cli import main as cli_main
+from renderkit.core.sequence import SequenceDetector
 
 
 def test_help_lists_ui_command(monkeypatch) -> None:
@@ -34,6 +37,47 @@ def test_ui_command_launches_gui(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert launched
+
+
+def test_convert_exr_sequence_accepts_three_digit_printf_pattern(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Verify CLI conversion can resolve a %03d input pattern."""
+    for frame in range(1, 4):
+        (tmp_path / f"shot.{frame:03d}.exr").touch()
+
+    output_path = tmp_path / "output.mp4"
+    resolved_paths: list[Path] = []
+
+    class FakeRenderKit:
+        def convert_with_config(self, config) -> None:
+            sequence = SequenceDetector.detect_sequence(config.input_pattern)
+            resolved_paths.extend(sequence.get_file_path(frame) for frame in sequence.frame_numbers)
+            output_path.touch()
+
+    monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
+    monkeypatch.setattr(cli_main, "setup_logging", lambda: None)
+    monkeypatch.setattr(cli_main, "RenderKit", FakeRenderKit)
+
+    result = CliRunner().invoke(
+        cli_main.main,
+        [
+            "convert-exr-sequence",
+            str(tmp_path / "shot.%03d.exr"),
+            str(output_path),
+            "--fps",
+            "24",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Successfully converted" in result.output
+    assert resolved_paths == [
+        tmp_path / "shot.001.exr",
+        tmp_path / "shot.002.exr",
+        tmp_path / "shot.003.exr",
+    ]
+    assert all(path.exists() for path in resolved_paths)
 
 
 def test_gui_alias_launches_gui(monkeypatch) -> None:

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -24,6 +24,31 @@ class TestSequenceDetector:
         assert sequence.frame_numbers == [1, 2, 3, 4, 5]
         assert sequence.padding == 4
 
+    def test_detect_percent_pattern_with_three_digit_padding(self, tmp_path: Path) -> None:
+        """Test detection and resolution of %03d pattern."""
+        (tmp_path / "shot.007.exr").touch()
+
+        pattern = str(tmp_path / "shot.%03d.exr")
+        sequence = SequenceDetector.detect_sequence(pattern)
+
+        assert len(sequence) == 1
+        assert sequence.frame_numbers == [7]
+        assert sequence.padding == 3
+        assert sequence.get_file_path(7) == tmp_path / "shot.007.exr"
+
+    def test_detect_percent_pattern_with_five_digit_padding(self, tmp_path: Path) -> None:
+        """Test detection and resolution of %05d pattern."""
+        for i in range(1, 4):
+            (tmp_path / f"shot.{i:05d}.exr").touch()
+
+        pattern = str(tmp_path / "shot.%05d.exr")
+        sequence = SequenceDetector.detect_sequence(pattern)
+
+        assert len(sequence) == 3
+        assert sequence.frame_numbers == [1, 2, 3]
+        assert sequence.padding == 5
+        assert sequence.get_file_path(2) == tmp_path / "shot.00002.exr"
+
     def test_detect_dollar_f_pattern(self, tmp_path: Path) -> None:
         """Test detection of $F4 pattern."""
         # Create test files
@@ -79,6 +104,22 @@ class TestSequenceDetector:
         file_path = sequence.get_file_path(3)
         assert file_path == tmp_path / "render.0003.exr"
         assert file_path.exists()
+
+    def test_get_file_path_resolves_multi_frame_percent_pattern(self, tmp_path: Path) -> None:
+        """Test resolving each frame in a %03d sequence."""
+        for i in range(1, 4):
+            (tmp_path / f"render.{i:03d}.exr").touch()
+
+        pattern = str(tmp_path / "render.%03d.exr")
+        sequence = SequenceDetector.detect_sequence(pattern)
+
+        paths = [sequence.get_file_path(frame) for frame in sequence.frame_numbers]
+        assert paths == [
+            tmp_path / "render.001.exr",
+            tmp_path / "render.002.exr",
+            tmp_path / "render.003.exr",
+        ]
+        assert all(path.exists() for path in paths)
 
 
 class TestFrameSequence:


### PR DESCRIPTION
## Summary
- resolve printf-style frame tokens using the token's actual width instead of only replacing `%04d`
- add regression coverage for `%03d`, `%04d`, and `%05d` path resolution
- add a CLI command smoke test proving `%03d` input patterns resolve to real frame paths

## Root cause
`SequenceDetector` accepted printf patterns such as `%03d`, but `FrameSequence.get_file_path()` only replaced the literal `%04d`, so conversion tried to open paths that still contained `%03d`.

## Validation
- `uv --native-tls run --extra dev pytest tests/test_sequence.py tests/test_cli.py`
- `uv --native-tls run --extra dev ruff check src\renderkit\core\sequence.py tests\test_sequence.py tests\test_cli.py`
- `uv --native-tls run --extra dev ruff format --check src\renderkit\core\sequence.py tests\test_sequence.py tests\test_cli.py`
- `uv --native-tls run --extra dev pytest`
- `uv --native-tls run --extra dev ruff check`

Closes #62


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Frame sequence handling now supports variable-width frame number padding patterns (e.g., `%03d`, `%05d`), enabling compatibility with image sequences using different digit widths for frame numbering.

* **Tests**
  * Added comprehensive test coverage for three-digit and five-digit padding patterns, validating correct sequence detection and frame path resolution across multiple frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->