### PR TITLE
Add automation-friendly progress control

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,9 +149,12 @@ $shots = Get-ChildItem .\shots -Directory
 foreach ($shot in $shots) {
     $pattern = Join-Path $shot.FullName "render.%04d.exr"
     $output = Join-Path $shot.FullName "review.mp4"
-    uv --native-tls run renderkit convert-exr-sequence $pattern $output --fps 24 --overwrite
+    uv --native-tls run renderkit convert-exr-sequence $pattern $output --fps 24 --overwrite --no-progress
 }
 ```
+
+Use `--no-progress` when capturing stdout or stderr from automation. RenderKit also disables
+progress bars automatically when stderr is not an interactive terminal.
 
 ### Bash Batch
 
@@ -189,6 +192,7 @@ done
 | `--cs-no-labels` | Disable layer name labels. | `False` |
 | `--profile` | Enable cProfile output for this conversion. | `False` |
 | `--profile-out` | Output `.prof` path or directory. | Temp dir |
+| `--no-progress` | Disable progress bars for stable captured logs. | `False` |
 
 ## `contact-sheet` Options
 

--- a/src/renderkit/api/processor.py
+++ b/src/renderkit/api/processor.py
@@ -36,6 +36,7 @@ class RenderKit:
         end_frame: Optional[int] = None,
         contact_sheet: bool = False,
         contact_sheet_config: Optional[ContactSheetConfig] = None,
+        show_progress: Optional[bool] = None,
     ) -> None:
         """Convert an EXR sequence to MP4 video.
 
@@ -52,6 +53,8 @@ class RenderKit:
             layer: Optional EXR layer to extract (default: None)
             start_frame: Start frame number (optional)
             end_frame: End frame number (optional)
+            show_progress: Whether to show the tqdm progress bar. When omitted, progress is shown
+                only when stderr is interactive.
 
         Example:
             >>> processor = RenderKit()
@@ -90,13 +93,17 @@ class RenderKit:
 
         conversion_config = config.build()
         converter = SequenceConverter(conversion_config)
-        converter.convert()
+        converter.convert(show_progress=show_progress)
 
-    def convert_with_config(self, config: ConversionConfig) -> None:
+    def convert_with_config(
+        self, config: ConversionConfig, show_progress: Optional[bool] = None
+    ) -> None:
         """Convert using a ConversionConfig object.
 
         Args:
             config: Conversion configuration object
+            show_progress: Whether to show the tqdm progress bar. When omitted, progress is shown
+                only when stderr is interactive.
 
         Example:
             >>> from renderkit.core.config import ConversionConfigBuilder
@@ -109,4 +116,4 @@ class RenderKit:
             >>> processor.convert_with_config(config)
         """
         converter = SequenceConverter(config)
-        converter.convert()
+        converter.convert(show_progress=show_progress)

--- a/src/renderkit/cli/main.py
+++ b/src/renderkit/cli/main.py
@@ -143,6 +143,12 @@ def gui() -> None:
     default=None,
     help="Output .prof file or directory (default: temp directory).",
 )
+@click.option(
+    "--no-progress",
+    is_flag=True,
+    default=False,
+    help="Disable progress bars for stable captured logs.",
+)
 def convert_exr_sequence(
     input_pattern: str,
     output_path: str,
@@ -168,6 +174,7 @@ def convert_exr_sequence(
     cs_no_labels: bool,
     profile: bool,
     profile_out: Optional[Path],
+    no_progress: bool,
 ) -> None:
     """Convert an EXR sequence to MP4 video.
 
@@ -278,7 +285,7 @@ def convert_exr_sequence(
             enabled, output_path_opt = get_profile_env_config()
 
         with profile_context(enabled, output_path_opt, label="cli-convert"):
-            processor.convert_with_config(config)
+            processor.convert_with_config(config, show_progress=False if no_progress else None)
         logger.info(f"Successfully converted to: {output_path}")
         click.echo(f"Successfully converted to: {output_path}")
     except (RenderKitError, OSError, RuntimeError, ValueError) as e:

--- a/src/renderkit/core/converter.py
+++ b/src/renderkit/core/converter.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import threading
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -97,8 +98,17 @@ class SequenceConverter:
         self.contact_sheet_generator: Optional[ContactSheetGenerator] = None
         self._layer_map = None
 
-    def convert(self, progress_callback: Optional[Callable[[int, int], None]] = None) -> None:
+    def convert(
+        self,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+        show_progress: Optional[bool] = None,
+    ) -> None:
         """Perform the conversion from image sequence to video.
+
+        Args:
+            progress_callback: Optional callback for UI or programmatic progress updates.
+            show_progress: Whether to show the CLI tqdm progress bar. When omitted, progress is
+                shown only when stderr is interactive.
 
         Raises:
             SequenceDetectionError: If sequence cannot be detected
@@ -132,6 +142,7 @@ class SequenceConverter:
             input_space,
             file_info,
             progress_callback,
+            show_progress,
         )
 
     def _detect_sequence(self) -> FrameSequence:
@@ -279,6 +290,7 @@ class SequenceConverter:
         input_space: Optional[str],
         file_info: FileInfo,
         progress_callback: Optional[Callable[[int, int], None]],
+        show_progress: Optional[bool],
     ) -> None:
         """Process all frames and write them to the encoder."""
         logger.debug(f"Processing {len(frame_numbers)} frames...")
@@ -301,6 +313,9 @@ class SequenceConverter:
         contact_sheet_enabled = (
             self.config.contact_sheet_mode and self.config.contact_sheet_config is not None
         )
+        if show_progress is None:
+            stderr_isatty = getattr(sys.stderr, "isatty", None)
+            show_progress = bool(stderr_isatty and stderr_isatty())
         pbar = None
 
         def _tick_progress(current_index: int) -> None:
@@ -312,7 +327,7 @@ class SequenceConverter:
                 pbar.update(1)
 
         try:
-            if progress_callback is None:
+            if progress_callback is None and show_progress:
                 from tqdm import tqdm
 
                 pbar = tqdm(total=total_frames, desc="Converting frames")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,3 +52,63 @@ def test_gui_alias_launches_gui(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert launched
+
+
+def test_convert_no_progress_disables_progress(monkeypatch, tmp_path) -> None:
+    """Verify --no-progress requests plain automation-friendly output."""
+    calls = []
+
+    class FakeRenderKit:
+        def convert_with_config(self, config, show_progress=None) -> None:
+            calls.append((config, show_progress))
+
+    monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
+    monkeypatch.setattr(cli_main, "setup_logging", lambda: None)
+    monkeypatch.setattr(cli_main, "RenderKit", FakeRenderKit)
+
+    result = CliRunner().invoke(
+        cli_main.main,
+        [
+            "convert-exr-sequence",
+            "render.%04d.exr",
+            str(tmp_path / "output.mp4"),
+            "--fps",
+            "24",
+            "--no-progress",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    _, show_progress = calls.pop()
+    assert show_progress is False
+    assert "Successfully converted" in result.output
+
+
+def test_convert_defaults_to_auto_progress_detection(monkeypatch, tmp_path) -> None:
+    """Verify default CLI behavior lets the converter decide from the terminal."""
+    calls = []
+
+    class FakeRenderKit:
+        def convert_with_config(self, config, show_progress=None) -> None:
+            calls.append((config, show_progress))
+
+    monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
+    monkeypatch.setattr(cli_main, "setup_logging", lambda: None)
+    monkeypatch.setattr(cli_main, "RenderKit", FakeRenderKit)
+
+    result = CliRunner().invoke(
+        cli_main.main,
+        [
+            "convert-exr-sequence",
+            "render.%04d.exr",
+            str(tmp_path / "output.mp4"),
+            "--fps",
+            "24",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    _, show_progress = calls.pop()
+    assert show_progress is None

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,9 +1,11 @@
 """Tests for converter (integration tests would require actual EXR files)."""
 
+import builtins
 from pathlib import Path
 
 import pytest
 
+from renderkit.core import converter as converter_module
 from renderkit.core.config import ConversionConfig, ConversionConfigBuilder
 from renderkit.core.converter import SequenceConverter
 from renderkit.exceptions import (
@@ -12,6 +14,7 @@ from renderkit.exceptions import (
     ImageReadError,
     VideoEncodingError,
 )
+from renderkit.io.file_info import FileInfo
 from renderkit.processing.video_encoder import VideoEncoder
 
 
@@ -257,3 +260,56 @@ class TestSequenceConverterFailures:
                 burnin_processor=None,
                 contact_sheet_generator=FailingContactSheetGenerator(),
             )
+
+
+class TestSequenceConverterProgress:
+    """Tests for CLI progress-bar behavior."""
+
+    def test_non_interactive_stderr_disables_tqdm_by_default(self, monkeypatch) -> None:
+        """Captured stderr should not create a tqdm progress bar."""
+
+        class FakeStderr:
+            def isatty(self) -> bool:
+                return False
+
+        class FakeEncoder:
+            def close(self) -> None:
+                # The progress test only verifies close() is called safely.
+                pass
+
+        real_import = builtins.__import__
+
+        def guarded_import(name, *args, **kwargs):
+            if name == "tqdm":
+                raise AssertionError("tqdm should not be imported for captured stderr")
+            return real_import(name, *args, **kwargs)
+
+        converter = SequenceConverter(
+            ConversionConfig(
+                input_pattern="render.%04d.exr",
+                output_path="output.mp4",
+                fps=24.0,
+            )
+        )
+        converter.sequence = _FakeSequence()
+        converter.encoder = FakeEncoder()
+
+        monkeypatch.setattr(converter_module.sys, "stderr", FakeStderr())
+        monkeypatch.setattr(builtins, "__import__", guarded_import)
+        monkeypatch.setattr(
+            converter,
+            "_process_single_frame_buf",
+            lambda *args, **kwargs: _FakeBuf(),
+        )
+
+        converter._process_frames(
+            frame_numbers=[1],
+            output_width=100,
+            output_height=100,
+            width=100,
+            height=100,
+            input_space=None,
+            file_info=FileInfo(width=100, height=100, channels=4, layers=[]),
+            progress_callback=None,
+            show_progress=None,
+        )


### PR DESCRIPTION
## Summary
- add `--no-progress` to `renderkit convert-exr-sequence` for automation-friendly logs
- auto-disable tqdm progress bars when stderr is not an interactive terminal
- thread `show_progress` through the Python API and document PowerShell batch usage

## Root cause
`SequenceConverter` created a tqdm progress bar whenever no UI progress callback was provided, even when CLI output was being captured by automation. In PowerShell capture scenarios, that progress stream could surface as noisy `System.Management.Automation.RemoteException` text even though the conversion succeeded.

## Validation
- `uv --native-tls run ruff check src/renderkit/cli/main.py src/renderkit/api/processor.py src/renderkit/core/converter.py tests/test_cli.py tests/test_converter.py`
- `uv --native-tls run pytest`

Closes #65
