### PR TITLE
Add verified sequence replacement cleanup

### DIFF
--- a/src/renderkit/cli/main.py
+++ b/src/renderkit/cli/main.py
@@ -17,6 +17,11 @@ from renderkit.core.config import (
 )
 from renderkit.core.ffmpeg_utils import ensure_ffmpeg_env
 from renderkit.core.profiler import get_profile_env_config, profile_context
+from renderkit.core.sequence_replacement import (
+    find_exr_sequences,
+    find_replacement_mp4,
+    replace_sequence_with_mp4,
+)
 from renderkit.exceptions import RenderKitError
 from renderkit.logging_utils import setup_logging
 from renderkit.processing.color_space import ColorSpacePreset
@@ -372,6 +377,145 @@ def contact_sheet(
         logger.exception("Contact sheet generation failed")
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
+
+
+@main.command(name="replace-sequence-with-mp4")
+@click.argument("input_pattern", type=str)
+@click.argument("output_mp4", type=click.Path(path_type=Path))
+@click.option(
+    "--delete-source",
+    is_flag=True,
+    default=False,
+    help="Delete source frames after the replacement MP4 is verified.",
+)
+@click.option(
+    "--verify",
+    is_flag=True,
+    default=False,
+    help="Verify the MP4 with ffprobe before replacing frames.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print and audit planned changes without copying or deleting files.",
+)
+@click.option(
+    "--audit-report",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="JSONL audit report path (default: source folder).",
+)
+def replace_sequence_command(
+    input_pattern: str,
+    output_mp4: Path,
+    delete_source: bool,
+    verify: bool,
+    dry_run: bool,
+    audit_report: Optional[Path],
+) -> None:
+    """Replace one detected image sequence with an MP4."""
+    try:
+        result = replace_sequence_with_mp4(
+            input_pattern,
+            output_mp4,
+            delete_source=delete_source,
+            verify=verify,
+            dry_run=dry_run,
+            audit_report=audit_report,
+        )
+    except RenderKitError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    action = "Would replace" if dry_run else "Replaced"
+    click.echo(f"{action}: {input_pattern}")
+    click.echo(f"MP4: {result.copied_mp4}")
+    if delete_source:
+        verb = "would delete" if dry_run else "deleted"
+        click.echo(f"Source frames {verb}: {result.deleted_count}")
+        click.echo(f"Reclaimed bytes: {result.reclaimed_bytes}")
+    click.echo(f"Audit report: {result.audit_report}")
+
+
+@main.command(name="batch-replace")
+@click.argument(
+    "root_path",
+    type=click.Path(path_type=Path, exists=True, file_okay=False, dir_okay=True),
+)
+@click.option(
+    "--mp4-dir",
+    type=click.Path(path_type=Path),
+    default=Path("_review_mp4s"),
+    show_default=True,
+    help="Directory containing replacement MP4s, relative to ROOT_PATH unless absolute.",
+)
+@click.option(
+    "--delete-source",
+    is_flag=True,
+    default=False,
+    help="Delete source frames after each replacement MP4 is verified.",
+)
+@click.option(
+    "--verify",
+    is_flag=True,
+    default=False,
+    help="Verify each MP4 with ffprobe before replacing frames.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print and audit planned changes without copying or deleting files.",
+)
+@click.option(
+    "--audit-report",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="JSONL audit report path (default: ROOT_PATH/renderkit-batch-replace-audit.jsonl).",
+)
+def batch_replace_command(
+    root_path: Path,
+    mp4_dir: Path,
+    delete_source: bool,
+    verify: bool,
+    dry_run: bool,
+    audit_report: Optional[Path],
+) -> None:
+    """Replace detected EXR sequences below ROOT_PATH with matching MP4s."""
+    mp4_root = mp4_dir if mp4_dir.is_absolute() else root_path / mp4_dir
+    report_path = audit_report or (root_path / "renderkit-batch-replace-audit.jsonl")
+    patterns = find_exr_sequences(root_path)
+    if not patterns:
+        click.echo(f"No EXR sequences found below: {root_path}")
+        return
+
+    results = []
+    try:
+        for pattern in patterns:
+            output_mp4 = find_replacement_mp4(pattern, mp4_root)
+            result = replace_sequence_with_mp4(
+                pattern,
+                output_mp4,
+                delete_source=delete_source,
+                verify=verify,
+                dry_run=dry_run,
+                audit_report=report_path,
+            )
+            results.append(result)
+    except RenderKitError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    action = "Would replace" if dry_run else "Replaced"
+    click.echo(f"{action} sequences: {len(results)}")
+    if delete_source:
+        deleted_count = sum(result.deleted_count for result in results)
+        reclaimed_bytes = sum(result.reclaimed_bytes for result in results)
+        verb = "would delete" if dry_run else "deleted"
+        click.echo(f"Source frames {verb}: {deleted_count}")
+        click.echo(f"Reclaimed bytes: {reclaimed_bytes}")
+    click.echo(f"Audit report: {report_path}")
 
 
 if __name__ == "__main__":

--- a/src/renderkit/core/ffmpeg_utils.py
+++ b/src/renderkit/core/ffmpeg_utils.py
@@ -98,6 +98,22 @@ def get_ffmpeg_exe() -> str:
     return "ffmpeg.exe" if sys.platform == "win32" else "ffmpeg"
 
 
+def get_ffprobe_exe() -> str:
+    """Return the best FFprobe executable path for the current environment."""
+    ffmpeg_exe = Path(get_ffmpeg_exe())
+    name = "ffprobe.exe" if sys.platform == "win32" else "ffprobe"
+    if ffmpeg_exe.parent:
+        sibling = ffmpeg_exe.with_name(name)
+        if sibling.is_file():
+            return str(sibling)
+
+    path_exe = shutil.which(name)
+    if path_exe:
+        return path_exe
+
+    return name
+
+
 def popen_kwargs(prevent_sigint: bool = True) -> dict[str, object]:
     """Return subprocess kwargs tuned for FFmpeg execution."""
     kwargs: dict[str, object] = {}

--- a/src/renderkit/core/sequence.py
+++ b/src/renderkit/core/sequence.py
@@ -46,7 +46,7 @@ class FrameSequence:
             lambda m: str(frame_number).zfill(int(m.group(1))),
             self.pattern,
         )
-        file_path = file_path.replace("$F4", frame_str)
+        file_path = re.sub(r"\$F\d+", frame_str, file_path)
         file_path = re.sub(r"#+", lambda m: frame_str.zfill(len(m.group())), file_path)
 
         return self.base_path / file_path
@@ -144,7 +144,8 @@ class SequenceDetector:
                 )
                 if frame_numbers:
                     padding = len(numeric_match.group(1))
-                    detected_pattern = filename
+                    start_pos, end_pos = numeric_match.span()
+                    detected_pattern = f"{filename[:start_pos]}%0{padding}d{filename[end_pos:]}"
 
         if not frame_numbers:
             raise SequenceDetectionError("Could not detect frame sequence.")
@@ -167,17 +168,19 @@ class SequenceDetector:
             List of frame numbers found
         """
         frame_numbers: list[int] = []
-        pattern_regex = pattern
-
-        # Convert pattern to regex
+        token_pattern = ""
         if placeholder == "%04d":
-            pattern_regex = re.sub(r"%\d+d", lambda m: r"(\d+)", pattern)
+            token_pattern = r"%\d+d"
         elif placeholder == "$F4":
-            pattern_regex = re.sub(r"\$F\d+", lambda m: r"(\d+)", pattern)
+            token_pattern = r"\$F\d+"
         elif placeholder == "####":
-            pattern_regex = re.sub(r"#+", lambda m: r"(\d+)", pattern)
+            token_pattern = r"#+"
 
-        regex = re.compile(pattern_regex)
+        parts = re.split(f"({token_pattern})", pattern, maxsplit=1)
+        if len(parts) != 3:
+            return frame_numbers
+
+        regex = re.compile(rf"^{re.escape(parts[0])}(\d{{{padding}}}){re.escape(parts[2])}$")
 
         # Search for matching files
         if base_path.exists():
@@ -214,7 +217,10 @@ class SequenceDetector:
 
         # Try to find files with same prefix/suffix but different numbers
         if base_path.exists():
-            pattern_regex = re.compile(re.escape(prefix) + r"(\d+)" + re.escape(suffix))
+            padding = end_pos - start_pos
+            pattern_regex = re.compile(
+                rf"^{re.escape(prefix)}(\d{{{padding}}}){re.escape(suffix)}$"
+            )
             for file_path in base_path.iterdir():
                 if file_path.is_file():
                     match = pattern_regex.match(file_path.name)

--- a/src/renderkit/core/sequence_replacement.py
+++ b/src/renderkit/core/sequence_replacement.py
@@ -127,35 +127,26 @@ def replace_sequence_with_mp4(
     source_mp4 = output_mp4.resolve()
     destination_mp4 = sequence.base_path / output_mp4.name
     report_path = audit_report or (sequence.base_path / "renderkit-replacement-audit.jsonl")
-    should_verify = verify or (delete_source and not dry_run)
-    verified = False
-
-    if should_verify:
-        verifier(source_mp4)
-        verified = True
-
-    if not dry_run and not source_mp4.is_file():
-        raise SequenceReplacementError(f"Replacement MP4 does not exist: {source_mp4}")
-
-    copied = False
-    if not dry_run and source_mp4 != destination_mp4.resolve():
-        shutil.copy2(source_mp4, destination_mp4)
-        copied = True
-        if delete_source:
-            verifier(destination_mp4)
-            verified = True
-    elif delete_source and not dry_run:
-        verifier(destination_mp4)
-        verified = True
-
-    deleted_frames: list[Path] = []
-    reclaimed_bytes = 0
-    if delete_source:
-        if dry_run:
-            deleted_frames = source_frames
-            reclaimed_bytes = _sum_existing_sizes(source_frames)
-        else:
-            deleted_frames, reclaimed_bytes = _delete_frames(source_frames)
+    verified = _verify_source_mp4_if_needed(
+        source_mp4,
+        delete_source=delete_source,
+        verify=verify,
+        dry_run=dry_run,
+        verifier=verifier,
+    )
+    copied, destination_verified = _copy_replacement_mp4(
+        source_mp4,
+        destination_mp4,
+        delete_source=delete_source,
+        dry_run=dry_run,
+        verifier=verifier,
+    )
+    verified = verified or destination_verified
+    deleted_frames, reclaimed_bytes = _delete_or_plan_frames(
+        source_frames,
+        delete_source=delete_source,
+        dry_run=dry_run,
+    )
 
     result = SequenceReplacementResult(
         source_pattern=input_pattern,
@@ -172,6 +163,61 @@ def replace_sequence_with_mp4(
     )
     _append_audit_record(report_path, result.to_audit_record())
     return result
+
+
+def _verify_source_mp4_if_needed(
+    source_mp4: Path,
+    *,
+    delete_source: bool,
+    verify: bool,
+    dry_run: bool,
+    verifier: Mp4Verifier,
+) -> bool:
+    should_verify = verify or (delete_source and not dry_run)
+    if not should_verify:
+        return False
+
+    verifier(source_mp4)
+    return True
+
+
+def _copy_replacement_mp4(
+    source_mp4: Path,
+    destination_mp4: Path,
+    *,
+    delete_source: bool,
+    dry_run: bool,
+    verifier: Mp4Verifier,
+) -> tuple[bool, bool]:
+    if dry_run:
+        return False, False
+
+    if not source_mp4.is_file():
+        raise SequenceReplacementError(f"Replacement MP4 does not exist: {source_mp4}")
+
+    copied = False
+    if source_mp4 != destination_mp4.resolve():
+        shutil.copy2(source_mp4, destination_mp4)
+        copied = True
+
+    if delete_source:
+        verifier(destination_mp4)
+        return copied, True
+
+    return copied, False
+
+
+def _delete_or_plan_frames(
+    source_frames: list[Path],
+    *,
+    delete_source: bool,
+    dry_run: bool,
+) -> tuple[list[Path], int]:
+    if not delete_source:
+        return [], 0
+    if dry_run:
+        return source_frames, _sum_existing_sizes(source_frames)
+    return _delete_frames(source_frames)
 
 
 def find_exr_sequences(root: Path) -> list[str]:

--- a/src/renderkit/core/sequence_replacement.py
+++ b/src/renderkit/core/sequence_replacement.py
@@ -235,11 +235,11 @@ def find_exr_sequences(root: Path) -> list[str]:
     for file_path in root.rglob("*.exr"):
         if not file_path.is_file():
             continue
-        match = re.match(r"^(?P<prefix>.*?)(?P<frame>\d+)(?P<suffix>\.[^.]+)$", file_path.name)
-        if not match:
+        numbered_name = _split_numbered_exr_name(file_path.name)
+        if numbered_name is None:
             continue
-        frame = match.group("frame")
-        key = (file_path.parent, match.group("prefix"), match.group("suffix"), len(frame))
+        prefix, frame, suffix = numbered_name
+        key = (file_path.parent, prefix, suffix, len(frame))
         groups.setdefault(key, []).append(int(frame))
 
     patterns = []
@@ -271,6 +271,22 @@ def _existing_sequence_frames(sequence: FrameSequence) -> list[Path]:
         for frame_number in sequence.frame_numbers
         if (path := sequence.get_file_path(frame_number)).is_file()
     ]
+
+
+def _split_numbered_exr_name(filename: str) -> Optional[tuple[str, str, str]]:
+    path = Path(filename)
+    if path.suffix.lower() != ".exr":
+        return None
+
+    stem = path.stem
+    frame_start = len(stem)
+    while frame_start > 0 and stem[frame_start - 1].isdigit():
+        frame_start -= 1
+
+    if frame_start == len(stem):
+        return None
+
+    return stem[:frame_start], stem[frame_start:], path.suffix
 
 
 def _sum_existing_sizes(paths: list[Path]) -> int:

--- a/src/renderkit/core/sequence_replacement.py
+++ b/src/renderkit/core/sequence_replacement.py
@@ -77,11 +77,13 @@ def verify_mp4_readable(mp4_path: Path) -> None:
         str(mp4_path),
     ]
     try:
-        result = subprocess.run(
+        # FFprobe receives fixed arguments and the MP4 path as a single argv item.
+        result = subprocess.run(  # NOSONAR
             command,
             capture_output=True,
             text=True,
             check=False,
+            shell=False,
             **popen_kwargs(),
         )
     except OSError as exc:

--- a/src/renderkit/core/sequence_replacement.py
+++ b/src/renderkit/core/sequence_replacement.py
@@ -129,6 +129,7 @@ def replace_sequence_with_mp4(
     source_mp4 = output_mp4.resolve()
     destination_mp4 = sequence.base_path / output_mp4.name
     report_path = audit_report or (sequence.base_path / "renderkit-replacement-audit.jsonl")
+    _prepare_audit_report(report_path)
     verified = _verify_source_mp4_if_needed(
         source_mp4,
         delete_source=delete_source,
@@ -306,9 +307,20 @@ def _delete_frames(paths: list[Path]) -> tuple[list[Path], int]:
 
 
 def _append_audit_record(audit_report: Path, record: dict[str, object]) -> None:
-    audit_report.parent.mkdir(parents=True, exist_ok=True)
-    with audit_report.open("a", encoding="utf-8") as stream:
-        stream.write(json.dumps(record, sort_keys=True) + "\n")
+    try:
+        with audit_report.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(record, sort_keys=True) + "\n")
+    except OSError as exc:
+        raise SequenceReplacementError(f"Could not write audit report: {audit_report}") from exc
+
+
+def _prepare_audit_report(audit_report: Path) -> None:
+    try:
+        audit_report.parent.mkdir(parents=True, exist_ok=True)
+        with audit_report.open("a", encoding="utf-8") as stream:
+            stream.flush()
+    except OSError as exc:
+        raise SequenceReplacementError(f"Could not write audit report: {audit_report}") from exc
 
 
 def _remove_frame_token(filename: str) -> str:

--- a/src/renderkit/core/sequence_replacement.py
+++ b/src/renderkit/core/sequence_replacement.py
@@ -192,11 +192,11 @@ def _copy_replacement_mp4(
     dry_run: bool,
     verifier: Mp4Verifier,
 ) -> tuple[bool, bool]:
-    if dry_run:
-        return False, False
-
     if not source_mp4.is_file():
         raise SequenceReplacementError(f"Replacement MP4 does not exist: {source_mp4}")
+
+    if dry_run:
+        return False, False
 
     copied = False
     if source_mp4 != destination_mp4.resolve():

--- a/src/renderkit/core/sequence_replacement.py
+++ b/src/renderkit/core/sequence_replacement.py
@@ -1,0 +1,254 @@
+"""Safe replacement of frame sequences with verified MP4 files."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Optional
+
+from renderkit.core.ffmpeg_utils import get_ffprobe_exe, popen_kwargs
+from renderkit.core.sequence import FrameSequence, SequenceDetector
+from renderkit.exceptions import SequenceReplacementError
+
+Mp4Verifier = Callable[[Path], None]
+
+
+@dataclass(frozen=True)
+class SequenceReplacementResult:
+    """Result of a sequence replacement operation."""
+
+    source_pattern: str
+    source_frames: list[Path]
+    replacement_mp4: Path
+    copied_mp4: Path
+    audit_report: Path
+    deleted_frames: list[Path]
+    deleted_count: int
+    reclaimed_bytes: int
+    dry_run: bool
+    verified: bool
+    copied: bool
+
+    def to_audit_record(self) -> dict[str, object]:
+        """Return a JSON-serializable audit record."""
+        return {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "source_pattern": self.source_pattern,
+            "source_frames": [str(path) for path in self.source_frames],
+            "source_count": len(self.source_frames),
+            "replacement_mp4": str(self.replacement_mp4),
+            "copied_mp4": str(self.copied_mp4),
+            "deleted_frames": [str(path) for path in self.deleted_frames],
+            "deleted_count": self.deleted_count,
+            "reclaimed_bytes": self.reclaimed_bytes,
+            "dry_run": self.dry_run,
+            "verified": self.verified,
+            "copied": self.copied,
+        }
+
+
+def verify_mp4_readable(mp4_path: Path) -> None:
+    """Verify that an MP4 exists and can be read by FFprobe.
+
+    Args:
+        mp4_path: MP4 file to verify.
+
+    Raises:
+        SequenceReplacementError: If the MP4 does not exist or FFprobe cannot read it.
+    """
+    if not mp4_path.is_file():
+        raise SequenceReplacementError(f"Replacement MP4 does not exist: {mp4_path}")
+
+    ffprobe_exe = get_ffprobe_exe()
+    command = [
+        ffprobe_exe,
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        str(mp4_path),
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            **popen_kwargs(),
+        )
+    except OSError as exc:
+        raise SequenceReplacementError(f"Could not run ffprobe: {exc}") from exc
+
+    if result.returncode != 0:
+        details = result.stderr.strip() or result.stdout.strip() or "ffprobe returned an error"
+        raise SequenceReplacementError(f"Replacement MP4 is not readable: {mp4_path} ({details})")
+
+
+def replace_sequence_with_mp4(
+    input_pattern: str,
+    output_mp4: Path,
+    *,
+    delete_source: bool = False,
+    verify: bool = False,
+    dry_run: bool = False,
+    audit_report: Optional[Path] = None,
+    verifier: Mp4Verifier = verify_mp4_readable,
+) -> SequenceReplacementResult:
+    """Replace one detected frame sequence with an MP4 and write an audit record.
+
+    Args:
+        input_pattern: Sequence pattern such as ``render.%04d.exr``.
+        output_mp4: MP4 file to copy into the source sequence directory.
+        delete_source: Whether to delete the source frame files after replacement.
+        verify: Whether to verify the MP4 with FFprobe before proceeding.
+        dry_run: Whether to only report planned actions.
+        audit_report: Optional JSONL audit path.
+        verifier: Verification callback used by tests.
+
+    Returns:
+        Result describing the replacement.
+
+    Raises:
+        SequenceReplacementError: If verification, copy, or deletion cannot proceed safely.
+    """
+    sequence = SequenceDetector.detect_sequence(input_pattern)
+    source_frames = _existing_sequence_frames(sequence)
+    if not source_frames:
+        raise SequenceReplacementError(f"No source frames found for pattern: {input_pattern}")
+
+    source_mp4 = output_mp4.resolve()
+    destination_mp4 = sequence.base_path / output_mp4.name
+    report_path = audit_report or (sequence.base_path / "renderkit-replacement-audit.jsonl")
+    should_verify = verify or (delete_source and not dry_run)
+    verified = False
+
+    if should_verify:
+        verifier(source_mp4)
+        verified = True
+
+    if not dry_run and not source_mp4.is_file():
+        raise SequenceReplacementError(f"Replacement MP4 does not exist: {source_mp4}")
+
+    copied = False
+    if not dry_run and source_mp4 != destination_mp4.resolve():
+        shutil.copy2(source_mp4, destination_mp4)
+        copied = True
+        if delete_source:
+            verifier(destination_mp4)
+            verified = True
+    elif delete_source and not dry_run:
+        verifier(destination_mp4)
+        verified = True
+
+    deleted_frames: list[Path] = []
+    reclaimed_bytes = 0
+    if delete_source:
+        if dry_run:
+            deleted_frames = source_frames
+            reclaimed_bytes = _sum_existing_sizes(source_frames)
+        else:
+            deleted_frames, reclaimed_bytes = _delete_frames(source_frames)
+
+    result = SequenceReplacementResult(
+        source_pattern=input_pattern,
+        source_frames=source_frames,
+        replacement_mp4=source_mp4,
+        copied_mp4=destination_mp4,
+        audit_report=report_path,
+        deleted_frames=deleted_frames,
+        deleted_count=len(deleted_frames) if delete_source else 0,
+        reclaimed_bytes=reclaimed_bytes if delete_source else 0,
+        dry_run=dry_run,
+        verified=verified,
+        copied=copied,
+    )
+    _append_audit_record(report_path, result.to_audit_record())
+    return result
+
+
+def find_exr_sequences(root: Path) -> list[str]:
+    """Find EXR sequence patterns below a directory.
+
+    Args:
+        root: Directory to scan recursively.
+
+    Returns:
+        Detected sequence patterns sorted by path.
+    """
+    groups: dict[tuple[Path, str, str, int], list[int]] = {}
+    for file_path in root.rglob("*.exr"):
+        if not file_path.is_file():
+            continue
+        match = re.match(r"^(?P<prefix>.*?)(?P<frame>\d+)(?P<suffix>\.[^.]+)$", file_path.name)
+        if not match:
+            continue
+        frame = match.group("frame")
+        key = (file_path.parent, match.group("prefix"), match.group("suffix"), len(frame))
+        groups.setdefault(key, []).append(int(frame))
+
+    patterns = []
+    for directory, prefix, suffix, padding in groups:
+        if not groups[(directory, prefix, suffix, padding)]:
+            continue
+        patterns.append(str(directory / f"{prefix}%0{padding}d{suffix}"))
+    return sorted(patterns)
+
+
+def find_replacement_mp4(sequence_pattern: str, mp4_dir: Path) -> Path:
+    """Return the expected MP4 replacement path for a sequence pattern.
+
+    Args:
+        sequence_pattern: Detected sequence pattern.
+        mp4_dir: Directory containing replacement MP4s.
+
+    Returns:
+        Expected MP4 path.
+    """
+    pattern_name = Path(sequence_pattern).name
+    stem = Path(_remove_frame_token(pattern_name)).stem.strip(" ._-")
+    return mp4_dir / f"{stem}.mp4"
+
+
+def _existing_sequence_frames(sequence: FrameSequence) -> list[Path]:
+    return [
+        path
+        for frame_number in sequence.frame_numbers
+        if (path := sequence.get_file_path(frame_number)).is_file()
+    ]
+
+
+def _sum_existing_sizes(paths: list[Path]) -> int:
+    return sum(path.stat().st_size for path in paths if path.is_file())
+
+
+def _delete_frames(paths: list[Path]) -> tuple[list[Path], int]:
+    deleted_frames = []
+    reclaimed_bytes = 0
+    for path in paths:
+        if not path.is_file():
+            continue
+        reclaimed_bytes += path.stat().st_size
+        path.unlink()
+        deleted_frames.append(path)
+    return deleted_frames, reclaimed_bytes
+
+
+def _append_audit_record(audit_report: Path, record: dict[str, object]) -> None:
+    audit_report.parent.mkdir(parents=True, exist_ok=True)
+    with audit_report.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def _remove_frame_token(filename: str) -> str:
+    filename = re.sub(r"%\d+d", "", filename)
+    filename = re.sub(r"\$F\d+", "", filename)
+    filename = re.sub(r"#+", "", filename)
+    return filename

--- a/src/renderkit/exceptions.py
+++ b/src/renderkit/exceptions.py
@@ -31,6 +31,12 @@ class VideoEncodingError(RenderKitError):
     pass
 
 
+class SequenceReplacementError(RenderKitError):
+    """Raised when replacing a frame sequence with a video fails."""
+
+    pass
+
+
 class ConfigurationError(RenderKitError):
     """Raised when configuration is invalid."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,8 @@ def test_help_lists_ui_command(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert "ui" in result.output
+    assert "batch-replace" in result.output
+    assert "replace-sequence-with-mp4" in result.output
     assert "Launch the RenderKit desktop UI." in result.output
     assert "gui" not in result.output
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,7 +52,7 @@ def test_convert_exr_sequence_accepts_three_digit_printf_pattern(
     resolved_paths: list[Path] = []
 
     class FakeRenderKit:
-        def convert_with_config(self, config) -> None:
+        def convert_with_config(self, config, show_progress=None) -> None:
             sequence = SequenceDetector.detect_sequence(config.input_pattern)
             resolved_paths.extend(sequence.get_file_path(frame) for frame in sequence.frame_numbers)
             output_path.touch()

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -121,6 +121,28 @@ class TestSequenceDetector:
         ]
         assert all(path.exists() for path in paths)
 
+    def test_detect_percent_pattern_uses_exact_filename_match(self, tmp_path: Path) -> None:
+        """Test sequence detection excludes partial filename matches."""
+        (tmp_path / "render.0001.exr").touch()
+        (tmp_path / "render.0001.exr.tmp").touch()
+        (tmp_path / "renderx0002.exr").touch()
+
+        pattern = str(tmp_path / "render.%04d.exr")
+        sequence = SequenceDetector.detect_sequence(pattern)
+
+        assert sequence.frame_numbers == [1]
+
+    def test_numeric_pattern_get_file_path_uses_detected_padding(self, tmp_path: Path) -> None:
+        """Test numeric sequence detection stores a reusable pattern."""
+        for i in range(1, 4):
+            (tmp_path / f"shot.{i:06d}.exr").touch()
+
+        pattern = str(tmp_path / "shot.000001.exr")
+        sequence = SequenceDetector.detect_sequence(pattern)
+
+        assert sequence.pattern == "shot.%06d.exr"
+        assert sequence.get_file_path(3) == tmp_path / "shot.000003.exr"
+
 
 class TestFrameSequence:
     """Tests for FrameSequence."""

--- a/tests/test_sequence_replacement.py
+++ b/tests/test_sequence_replacement.py
@@ -67,6 +67,28 @@ def test_replace_sequence_refuses_delete_when_verification_fails(tmp_path: Path)
     assert all(path.exists() for path in frames)
 
 
+def test_replace_sequence_refuses_delete_when_audit_report_is_unwritable(
+    tmp_path: Path,
+) -> None:
+    """Verify source frames survive when the audit report cannot be opened."""
+    frames = _write_sequence(tmp_path)
+    mp4_path = tmp_path / "render.mp4"
+    mp4_path.write_bytes(b"mp4")
+    audit_parent = tmp_path / "audit-parent"
+    audit_parent.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(SequenceReplacementError, match="Could not write audit report"):
+        replace_sequence_with_mp4(
+            str(tmp_path / "render.%04d.exr"),
+            mp4_path,
+            delete_source=True,
+            audit_report=audit_parent / "audit.jsonl",
+            verifier=lambda _path: None,
+        )
+
+    assert all(path.exists() for path in frames)
+
+
 def test_replace_sequence_copies_verified_mp4_then_deletes_frames(tmp_path: Path) -> None:
     """Verify a successful replacement copies the MP4 and deletes exact source frames."""
     frames = _write_sequence(tmp_path)

--- a/tests/test_sequence_replacement.py
+++ b/tests/test_sequence_replacement.py
@@ -1,0 +1,111 @@
+"""Tests for safe sequence replacement cleanup."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from renderkit.core.sequence_replacement import (
+    find_exr_sequences,
+    find_replacement_mp4,
+    replace_sequence_with_mp4,
+)
+from renderkit.exceptions import SequenceReplacementError
+
+
+def _write_sequence(tmp_path: Path, name: str = "render", count: int = 3) -> list[Path]:
+    paths = []
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    for frame in range(1, count + 1):
+        path = tmp_path / f"{name}.{frame:04d}.exr"
+        path.write_bytes(b"frame")
+        paths.append(path)
+    return paths
+
+
+def test_replace_sequence_dry_run_writes_audit_without_deleting(tmp_path: Path) -> None:
+    """Verify dry-run records planned source deletion without unlinking files."""
+    frames = _write_sequence(tmp_path)
+    mp4_path = tmp_path / "_review_mp4s" / "render.mp4"
+    mp4_path.parent.mkdir()
+    mp4_path.write_bytes(b"mp4")
+    audit_path = tmp_path / "audit.jsonl"
+
+    result = replace_sequence_with_mp4(
+        str(tmp_path / "render.%04d.exr"),
+        mp4_path,
+        delete_source=True,
+        dry_run=True,
+        audit_report=audit_path,
+    )
+
+    assert result.dry_run is True
+    assert result.deleted_count == 3
+    assert all(path.exists() for path in frames)
+    record = json.loads(audit_path.read_text(encoding="utf-8").strip())
+    assert record["dry_run"] is True
+    assert record["deleted_count"] == 3
+
+
+def test_replace_sequence_refuses_delete_when_verification_fails(tmp_path: Path) -> None:
+    """Verify source frames survive when MP4 verification fails."""
+    frames = _write_sequence(tmp_path)
+    mp4_path = tmp_path / "render.mp4"
+    mp4_path.write_bytes(b"not a real video")
+
+    def fail_verifier(path: Path) -> None:
+        raise SequenceReplacementError(f"unreadable: {path}")
+
+    with pytest.raises(SequenceReplacementError, match="unreadable"):
+        replace_sequence_with_mp4(
+            str(tmp_path / "render.%04d.exr"),
+            mp4_path,
+            delete_source=True,
+            verifier=fail_verifier,
+        )
+
+    assert all(path.exists() for path in frames)
+
+
+def test_replace_sequence_copies_verified_mp4_then_deletes_frames(tmp_path: Path) -> None:
+    """Verify a successful replacement copies the MP4 and deletes exact source frames."""
+    frames = _write_sequence(tmp_path)
+    stray = tmp_path / "render.0001.exr.tmp"
+    stray.write_bytes(b"keep")
+    mp4_path = tmp_path / "_review_mp4s" / "render.mp4"
+    mp4_path.parent.mkdir()
+    mp4_path.write_bytes(b"mp4")
+    verified_paths = []
+
+    def verifier(path: Path) -> None:
+        verified_paths.append(path)
+
+    result = replace_sequence_with_mp4(
+        str(tmp_path / "render.%04d.exr"),
+        mp4_path,
+        delete_source=True,
+        verifier=verifier,
+    )
+
+    assert result.deleted_count == 3
+    assert result.reclaimed_bytes == 15
+    assert not any(path.exists() for path in frames)
+    assert stray.exists()
+    assert (tmp_path / "render.mp4").exists()
+    assert verified_paths == [mp4_path.resolve(), tmp_path / "render.mp4"]
+
+
+def test_find_exr_sequences_and_matching_mp4(tmp_path: Path) -> None:
+    """Verify batch helpers derive sequence patterns and MP4 names."""
+    _write_sequence(tmp_path, name="beauty")
+    _write_sequence(tmp_path / "nested", name="depth", count=2)
+
+    patterns = find_exr_sequences(tmp_path)
+
+    assert patterns == [
+        str(tmp_path / "beauty.%04d.exr"),
+        str(tmp_path / "nested" / "depth.%04d.exr"),
+    ]
+    assert find_replacement_mp4(patterns[0], tmp_path / "_review_mp4s") == (
+        tmp_path / "_review_mp4s" / "beauty.mp4"
+    )

--- a/tests/test_sequence_replacement.py
+++ b/tests/test_sequence_replacement.py
@@ -47,6 +47,22 @@ def test_replace_sequence_dry_run_writes_audit_without_deleting(tmp_path: Path) 
     assert record["deleted_count"] == 3
 
 
+def test_replace_sequence_dry_run_requires_replacement_mp4(tmp_path: Path) -> None:
+    """Verify dry-run fails when the planned replacement MP4 is missing."""
+    frames = _write_sequence(tmp_path)
+    missing_mp4 = tmp_path / "_review_mp4s" / "render.mp4"
+
+    with pytest.raises(SequenceReplacementError, match="Replacement MP4 does not exist"):
+        replace_sequence_with_mp4(
+            str(tmp_path / "render.%04d.exr"),
+            missing_mp4,
+            delete_source=True,
+            dry_run=True,
+        )
+
+    assert all(path.exists() for path in frames)
+
+
 def test_replace_sequence_refuses_delete_when_verification_fails(tmp_path: Path) -> None:
     """Verify source frames survive when MP4 verification fails."""
     frames = _write_sequence(tmp_path)


### PR DESCRIPTION
## Summary
- add `replace-sequence-with-mp4` for safe single-sequence MP4 replacement cleanup
- add `batch-replace` for scanning EXR sequence groups and matching review MP4s
- verify MP4 readability with ffprobe before destructive cleanup and write JSONL audit records
- tighten sequence matching so cleanup only targets exact detected frames
- validate replacement MP4 existence during dry-run so destructive preflight cannot report missing MP4s as replaceable

## Validation
- `uv --system-certs run --extra dev ruff format --check .`
- `uv --system-certs run --extra dev ruff check .`
- `uv --system-certs run --extra dev pytest tests/test_sequence_replacement.py tests/test_sequence.py tests/test_cli.py`
- `uv --system-certs run --extra dev python -m pytest tests/ -v -k "not test_ui" --cov=renderkit --cov-report=xml`
- GitHub CI: lint/format, type check, Ubuntu/Windows Python 3.13 tests, UI tests, build package all passed
- SonarCloud Code Analysis passed
- CodeRabbit review completed

## Merge Verdict
Ready to merge. PR is non-draft, merge state is clean, CI is green, SonarCloud is clean, and the review finding about dry-run false positives is fixed with regression coverage.

Closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `replace-sequence-with-mp4` command to replace frame sequences with MP4 videos, with support for dry-run mode, verification, deletion options, and optional audit logging.
  * Added `batch-replace` command to process multiple sequences under a directory.

* **Tests**
  * Enhanced test coverage for sequence detection and replacement operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->