### PR TITLE
Fix sequence replacement audit preflight

### DIFF
--- a/src/renderkit/core/sequence_replacement.py
+++ b/src/renderkit/core/sequence_replacement.py
@@ -129,6 +129,7 @@ def replace_sequence_with_mp4(
     source_mp4 = output_mp4.resolve()
     destination_mp4 = sequence.base_path / output_mp4.name
     report_path = audit_report or (sequence.base_path / "renderkit-replacement-audit.jsonl")
+    _prepare_audit_report(report_path)
     verified = _verify_source_mp4_if_needed(
         source_mp4,
         delete_source=delete_source,
@@ -306,9 +307,20 @@ def _delete_frames(paths: list[Path]) -> tuple[list[Path], int]:
 
 
 def _append_audit_record(audit_report: Path, record: dict[str, object]) -> None:
-    audit_report.parent.mkdir(parents=True, exist_ok=True)
-    with audit_report.open("a", encoding="utf-8") as stream:
-        stream.write(json.dumps(record, sort_keys=True) + "\n")
+    try:
+        with audit_report.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(record, sort_keys=True) + "\n")
+    except OSError as exc:
+        raise SequenceReplacementError(f"Could not write audit report: {audit_report}") from exc
+
+
+def _prepare_audit_report(audit_report: Path) -> None:
+    try:
+        audit_report.parent.mkdir(parents=True, exist_ok=True)
+        with audit_report.open("a", encoding="utf-8") as stream:
+            stream.flush()
+    except OSError as exc:
+        raise SequenceReplacementError(f"Could not write audit report: {audit_report}") from exc
 
 
 def _remove_frame_token(filename: str) -> str:

--- a/tests/test_sequence_replacement.py
+++ b/tests/test_sequence_replacement.py
@@ -67,6 +67,28 @@ def test_replace_sequence_refuses_delete_when_verification_fails(tmp_path: Path)
     assert all(path.exists() for path in frames)
 
 
+def test_replace_sequence_refuses_delete_when_audit_report_is_unwritable(
+    tmp_path: Path,
+) -> None:
+    """Verify source frames survive when the audit report cannot be opened."""
+    frames = _write_sequence(tmp_path)
+    mp4_path = tmp_path / "render.mp4"
+    mp4_path.write_bytes(b"mp4")
+    audit_parent = tmp_path / "audit-parent"
+    audit_parent.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(SequenceReplacementError, match="Could not write audit report"):
+        replace_sequence_with_mp4(
+            str(tmp_path / "render.%04d.exr"),
+            mp4_path,
+            delete_source=True,
+            audit_report=audit_parent / "audit.jsonl",
+            verifier=lambda _path: None,
+        )
+
+    assert all(path.exists() for path in frames)
+
+
 def test_replace_sequence_copies_verified_mp4_then_deletes_frames(tmp_path: Path) -> None:
     """Verify a successful replacement copies the MP4 and deletes exact source frames."""
     frames = _write_sequence(tmp_path)


### PR DESCRIPTION
## Summary
- preflight audit report writability before copy/delete work
- wrap audit write failures as SequenceReplacementError
- add a regression test proving source frames survive when the audit path is unwritable

## Tests
- uv --system-certs run --extra dev pytest tests/test_sequence.py tests/test_sequence_replacement.py tests/test_cli.py
- uv --system-certs run --extra dev ruff check src/renderkit/core/sequence_replacement.py tests/test_sequence_replacement.py