### PR TITLE
Add batch EXR sequence conversion CLI

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,6 +20,7 @@ If RenderKit is already installed or you are using a release build that adds the
 renderkit --help
 renderkit ui
 renderkit convert-exr-sequence INPUT_PATTERN OUTPUT_PATH [OPTIONS]
+renderkit batch-convert ROOT [OPTIONS]
 renderkit contact-sheet INPUT_PATTERN OUTPUT_PATH [OPTIONS]
 ```
 
@@ -164,6 +165,24 @@ for shot in shots/*; do
 done
 ```
 
+### Recursive Batch Convert
+
+Use `batch-convert` when RenderKit should discover sequences recursively and write review MP4s
+plus audit manifests:
+
+```powershell
+renderkit batch-convert G:\Projects\Data_folder --ext exr --out _review_mp4s --fps 24 --overwrite
+```
+
+By default, relative output and manifest paths are resolved under `ROOT`. Existing MP4s are
+skipped unless `--overwrite` is set. The command keeps processing after per-sequence failures and
+exits nonzero if any sequence failed.
+
+Default manifests:
+
+- `_review_mp4s/renderkit_batch_manifest.csv`
+- `_review_mp4s/renderkit_batch_results.jsonl`
+
 ## `convert-exr-sequence` Options
 
 | Option | Description | Default |
@@ -192,6 +211,26 @@ done
 | `--cs-no-labels` | Disable layer name labels. | `False` |
 | `--profile` | Enable cProfile output for this conversion. | `False` |
 | `--profile-out` | Output `.prof` path or directory. | Temp dir |
+| `--no-progress` | Disable progress bars for stable captured logs. | `False` |
+
+## `batch-convert` Options
+
+| Option | Description | Default |
+|---|---|---|
+| `ROOT` | Directory tree to scan recursively. | Required |
+| `--ext` | Frame extension to discover, with or without a leading dot. | `exr` |
+| `--out` | Output directory for generated MP4 files. Relative paths resolve under `ROOT`. | `_review_mp4s` |
+| `--prefetch-workers` | Number of frame prefetch workers; use `1` to disable concurrent prefetch. | `2` |
+| `--fps` | Frame rate. If omitted, RenderKit attempts auto-detection per sequence. | Auto-detect |
+| `--quality` | Visual quality on a 0-10 scale. | `10` |
+| `--color-space` | `linear_to_srgb`, `linear_to_rec709`, `srgb_to_linear`, or `no_conversion`. | `linear_to_srgb` |
+| `--width` | Output width. Must be paired with `--height`. | Source width |
+| `--height` | Output height. Must be paired with `--width`. | Source height |
+| `--codec` | FFmpeg codec, commonly `libx264`, `libx265`, or `libaom-av1`. | `libx264` |
+| `--layer` | EXR layer/AOV to extract. | None |
+| `--overwrite` | Overwrite output files if they exist. | `False` |
+| `--manifest-csv` | CSV manifest path. Relative paths resolve under `ROOT`. | `OUTPUT_DIR/renderkit_batch_manifest.csv` |
+| `--manifest-jsonl` | JSONL results path. Relative paths resolve under `ROOT`. | `OUTPUT_DIR/renderkit_batch_results.jsonl` |
 | `--no-progress` | Disable progress bars for stable captured logs. | `False` |
 
 ## `contact-sheet` Options

--- a/src/renderkit/cli/main.py
+++ b/src/renderkit/cli/main.py
@@ -2,8 +2,9 @@
 
 import logging
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional, TypeVar
 
 import click
 
@@ -39,6 +40,117 @@ COLOR_SPACE_MAP = {
     "srgb_to_linear": ColorSpacePreset.SRGB_TO_LINEAR,
     "no_conversion": ColorSpacePreset.NO_CONVERSION,
 }
+
+F = TypeVar("F", bound=Callable[..., Any])
+ClickOptionSpec = tuple[tuple[str, ...], dict[str, Any]]
+
+
+BATCH_CONVERT_OPTIONS: tuple[ClickOptionSpec, ...] = (
+    (
+        ("--ext",),
+        {"type": str, "default": "exr", "show_default": True, "help": "Input frame extension."},
+    ),
+    (
+        ("--out", "output_dir"),
+        {
+            "type": click.Path(path_type=Path),
+            "default": Path("_review_mp4s"),
+            "show_default": True,
+            "help": "Output directory for generated MP4 files.",
+        },
+    ),
+    (
+        ("--prefetch-workers",),
+        {
+            "type": int,
+            "default": 2,
+            "show_default": True,
+            "help": "Number of frame prefetch workers (set to 1 to disable).",
+        },
+    ),
+    (
+        ("--fps",),
+        {
+            "type": float,
+            "default": None,
+            "help": "Frame rate (fps). If not provided, will attempt auto-detection per sequence.",
+        },
+    ),
+    (
+        ("--color-space",),
+        {
+            "type": click.Choice(
+                ["linear_to_srgb", "linear_to_rec709", "srgb_to_linear", "no_conversion"],
+                case_sensitive=False,
+            ),
+            "default": "linear_to_srgb",
+            "help": "Color space conversion preset (default: linear_to_srgb)",
+        },
+    ),
+    (("--width",), {"type": int, "default": None, "help": "Output width (default: source width)"}),
+    (
+        ("--height",),
+        {"type": int, "default": None, "help": "Output height (default: source height)"},
+    ),
+    (
+        ("--codec",),
+        {
+            "type": str,
+            "default": "libx264",
+            "help": "Video codec (default: libx264, use 'libaom-av1' for AV1)",
+        },
+    ),
+    (
+        ("--quality",),
+        {
+            "type": click.IntRange(0, 10),
+            "default": 10,
+            "help": "Video quality (0-10), 10 is best (default: 10). Sets CRF.",
+        },
+    ),
+    (
+        ("--layer",),
+        {"type": str, "default": None, "help": "Specific EXR layer to extract (e.g., 'diffuse')."},
+    ),
+    (
+        ("--overwrite",),
+        {"is_flag": True, "default": False, "help": "Overwrite output files if they exist."},
+    ),
+    (
+        ("--manifest-csv",),
+        {
+            "type": click.Path(path_type=Path),
+            "default": None,
+            "help": "CSV manifest path (default: OUTPUT_DIR/renderkit_batch_manifest.csv).",
+        },
+    ),
+    (
+        ("--manifest-jsonl",),
+        {
+            "type": click.Path(path_type=Path),
+            "default": None,
+            "help": "JSONL results path (default: OUTPUT_DIR/renderkit_batch_results.jsonl).",
+        },
+    ),
+    (
+        ("--no-progress",),
+        {
+            "is_flag": True,
+            "default": False,
+            "help": "Disable progress bars for stable captured logs.",
+        },
+    ),
+)
+
+
+def _apply_click_options(option_specs: tuple[ClickOptionSpec, ...]) -> Callable[[F], F]:
+    def decorator(func: F) -> F:
+        decorated = func
+        for param_decls, attrs in reversed(option_specs):
+            decorated = click.option(*param_decls, **attrs)(decorated)
+        return decorated
+
+    return decorator
 
 
 @click.group()
@@ -221,18 +333,18 @@ def convert_exr_sequence(
         click.echo("Use --overwrite to overwrite it.", err=True)
         sys.exit(1)
 
-    color_space_preset = COLOR_SPACE_MAP[color_space.lower()]
-
     # Build configuration
-    config_builder = (
-        ConversionConfigBuilder()
-        .with_input_pattern(input_pattern)
-        .with_output_path(output_path)
-        .with_prefetch_workers(prefetch_workers)
-        .with_color_space_preset(color_space_preset)
-        .with_codec(codec)
-        .with_quality(quality)
-        .with_layer(layer)
+    config_builder = _base_conversion_config_builder(
+        input_pattern=input_pattern,
+        output_path=output_path,
+        prefetch_workers=prefetch_workers,
+        fps=fps,
+        color_space=color_space,
+        width=width,
+        height=height,
+        codec=codec,
+        quality=quality,
+        layer=layer,
     )
 
     if contact_sheet:
@@ -245,12 +357,6 @@ def convert_exr_sequence(
             show_labels=not cs_no_labels,
         )
         config_builder.with_contact_sheet(True, cs_config)
-
-    if fps is not None:
-        config_builder.with_fps(fps)
-
-    if width is not None and height is not None:
-        config_builder.with_resolution(width, height)
 
     if start_frame is not None and end_frame is not None:
         config_builder.with_frame_range(start_frame, end_frame)
@@ -306,81 +412,7 @@ def convert_exr_sequence(
 
 @main.command(name="batch-convert")
 @click.argument("root", type=click.Path(path_type=Path))
-@click.option("--ext", type=str, default="exr", show_default=True, help="Input frame extension.")
-@click.option(
-    "--out",
-    "output_dir",
-    type=click.Path(path_type=Path),
-    default=Path("_review_mp4s"),
-    show_default=True,
-    help="Output directory for generated MP4 files.",
-)
-@click.option(
-    "--prefetch-workers",
-    type=int,
-    default=2,
-    show_default=True,
-    help="Number of frame prefetch workers (set to 1 to disable).",
-)
-@click.option(
-    "--fps",
-    type=float,
-    default=None,
-    help="Frame rate (fps). If not provided, will attempt auto-detection per sequence.",
-)
-@click.option(
-    "--color-space",
-    type=click.Choice(
-        ["linear_to_srgb", "linear_to_rec709", "srgb_to_linear", "no_conversion"],
-        case_sensitive=False,
-    ),
-    default="linear_to_srgb",
-    help="Color space conversion preset (default: linear_to_srgb)",
-)
-@click.option("--width", type=int, default=None, help="Output width (default: source width)")
-@click.option("--height", type=int, default=None, help="Output height (default: source height)")
-@click.option(
-    "--codec",
-    type=str,
-    default="libx264",
-    help="Video codec (default: libx264, use 'libaom-av1' for AV1)",
-)
-@click.option(
-    "--quality",
-    type=click.IntRange(0, 10),
-    default=10,
-    help="Video quality (0-10), 10 is best (default: 10). Sets CRF.",
-)
-@click.option(
-    "--layer",
-    type=str,
-    default=None,
-    help="Specific EXR layer to extract (e.g., 'diffuse').",
-)
-@click.option(
-    "--overwrite",
-    is_flag=True,
-    default=False,
-    help="Overwrite output files if they exist.",
-)
-@click.option(
-    "--manifest-csv",
-    type=click.Path(path_type=Path),
-    default=None,
-    help="CSV manifest path (default: OUTPUT_DIR/renderkit_batch_manifest.csv).",
-)
-@click.option(
-    "--manifest-jsonl",
-    type=click.Path(path_type=Path),
-    default=None,
-    help="JSONL results path (default: OUTPUT_DIR/renderkit_batch_results.jsonl).",
-)
-@click.option(
-    "--no-progress",
-    is_flag=True,
-    default=False,
-    help="Disable progress bars for stable captured logs.",
-)
+@_apply_click_options(BATCH_CONVERT_OPTIONS)
 def batch_convert(
     root: Path,
     ext: str,
@@ -505,6 +537,40 @@ def _deduplicate_batch_output_path(output_path: Path, planned_outputs: set[Path]
         index += 1
 
 
+def _base_conversion_config_builder(
+    input_pattern: str,
+    output_path: str,
+    prefetch_workers: int,
+    fps: Optional[float],
+    color_space: str,
+    width: Optional[int],
+    height: Optional[int],
+    codec: str,
+    quality: int,
+    layer: Optional[str],
+) -> ConversionConfigBuilder:
+    config_builder = (
+        ConversionConfigBuilder()
+        .with_input_pattern(input_pattern)
+        .with_output_path(output_path)
+        .with_prefetch_workers(prefetch_workers)
+        .with_color_space_preset(COLOR_SPACE_MAP[color_space.lower()])
+        .with_codec(codec)
+        .with_quality(quality)
+    )
+
+    if layer is not None:
+        config_builder.with_layer(layer)
+
+    if fps is not None:
+        config_builder.with_fps(fps)
+
+    if width is not None and height is not None:
+        config_builder.with_resolution(width, height)
+
+    return config_builder
+
+
 def _build_batch_conversion_config(
     input_pattern: str,
     output_path: str,
@@ -517,24 +583,18 @@ def _build_batch_conversion_config(
     quality: int,
     layer: Optional[str],
 ) -> ConversionConfig:
-    config_builder = (
-        ConversionConfigBuilder()
-        .with_input_pattern(input_pattern)
-        .with_output_path(output_path)
-        .with_prefetch_workers(prefetch_workers)
-        .with_color_space_preset(COLOR_SPACE_MAP[color_space.lower()])
-        .with_codec(codec)
-        .with_quality(quality)
-        .with_layer(layer)
-    )
-
-    if fps is not None:
-        config_builder.with_fps(fps)
-
-    if width is not None and height is not None:
-        config_builder.with_resolution(width, height)
-
-    return config_builder.build()
+    return _base_conversion_config_builder(
+        input_pattern=input_pattern,
+        output_path=output_path,
+        prefetch_workers=prefetch_workers,
+        fps=fps,
+        color_space=color_space,
+        width=width,
+        height=height,
+        codec=codec,
+        quality=quality,
+        layer=layer,
+    ).build()
 
 
 def _batch_record(

--- a/src/renderkit/cli/main.py
+++ b/src/renderkit/cli/main.py
@@ -9,10 +9,19 @@ import click
 
 from renderkit import __version__
 from renderkit.api.processor import RenderKit
+from renderkit.core.batch import (
+    BatchManifestRecord,
+    BatchSequence,
+    append_jsonl_manifest,
+    build_safe_output_path,
+    discover_frame_sequences,
+    write_csv_manifest,
+)
 from renderkit.core.config import (
     BurnInConfig,
     BurnInElement,
     ContactSheetConfigBuilder,
+    ConversionConfig,
     ConversionConfigBuilder,
 )
 from renderkit.core.ffmpeg_utils import ensure_ffmpeg_env
@@ -22,6 +31,14 @@ from renderkit.logging_utils import setup_logging
 from renderkit.processing.color_space import ColorSpacePreset
 
 logger = logging.getLogger("renderkit.cli.main")
+
+
+COLOR_SPACE_MAP = {
+    "linear_to_srgb": ColorSpacePreset.LINEAR_TO_SRGB,
+    "linear_to_rec709": ColorSpacePreset.LINEAR_TO_REC709,
+    "srgb_to_linear": ColorSpacePreset.SRGB_TO_LINEAR,
+    "no_conversion": ColorSpacePreset.NO_CONVERSION,
+}
 
 
 @click.group()
@@ -204,14 +221,7 @@ def convert_exr_sequence(
         click.echo("Use --overwrite to overwrite it.", err=True)
         sys.exit(1)
 
-    # Map color space string to enum
-    color_space_map = {
-        "linear_to_srgb": ColorSpacePreset.LINEAR_TO_SRGB,
-        "linear_to_rec709": ColorSpacePreset.LINEAR_TO_REC709,
-        "srgb_to_linear": ColorSpacePreset.SRGB_TO_LINEAR,
-        "no_conversion": ColorSpacePreset.NO_CONVERSION,
-    }
-    color_space_preset = color_space_map[color_space.lower()]
+    color_space_preset = COLOR_SPACE_MAP[color_space.lower()]
 
     # Build configuration
     config_builder = (
@@ -292,6 +302,257 @@ def convert_exr_sequence(
         logger.exception("Conversion failed")
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
+
+
+@main.command(name="batch-convert")
+@click.argument("root", type=click.Path(path_type=Path))
+@click.option("--ext", type=str, default="exr", show_default=True, help="Input frame extension.")
+@click.option(
+    "--out",
+    "output_dir",
+    type=click.Path(path_type=Path),
+    default=Path("_review_mp4s"),
+    show_default=True,
+    help="Output directory for generated MP4 files.",
+)
+@click.option(
+    "--prefetch-workers",
+    type=int,
+    default=2,
+    show_default=True,
+    help="Number of frame prefetch workers (set to 1 to disable).",
+)
+@click.option(
+    "--fps",
+    type=float,
+    default=None,
+    help="Frame rate (fps). If not provided, will attempt auto-detection per sequence.",
+)
+@click.option(
+    "--color-space",
+    type=click.Choice(
+        ["linear_to_srgb", "linear_to_rec709", "srgb_to_linear", "no_conversion"],
+        case_sensitive=False,
+    ),
+    default="linear_to_srgb",
+    help="Color space conversion preset (default: linear_to_srgb)",
+)
+@click.option("--width", type=int, default=None, help="Output width (default: source width)")
+@click.option("--height", type=int, default=None, help="Output height (default: source height)")
+@click.option(
+    "--codec",
+    type=str,
+    default="libx264",
+    help="Video codec (default: libx264, use 'libaom-av1' for AV1)",
+)
+@click.option(
+    "--quality",
+    type=click.IntRange(0, 10),
+    default=10,
+    help="Video quality (0-10), 10 is best (default: 10). Sets CRF.",
+)
+@click.option(
+    "--layer",
+    type=str,
+    default=None,
+    help="Specific EXR layer to extract (e.g., 'diffuse').",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Overwrite output files if they exist.",
+)
+@click.option(
+    "--manifest-csv",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="CSV manifest path (default: OUTPUT_DIR/renderkit_batch_manifest.csv).",
+)
+@click.option(
+    "--manifest-jsonl",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="JSONL results path (default: OUTPUT_DIR/renderkit_batch_results.jsonl).",
+)
+@click.option(
+    "--no-progress",
+    is_flag=True,
+    default=False,
+    help="Disable progress bars for stable captured logs.",
+)
+def batch_convert(
+    root: Path,
+    ext: str,
+    output_dir: Path,
+    prefetch_workers: int,
+    fps: Optional[float],
+    color_space: str,
+    width: Optional[int],
+    height: Optional[int],
+    codec: str,
+    quality: int,
+    layer: Optional[str],
+    overwrite: bool,
+    manifest_csv: Optional[Path],
+    manifest_jsonl: Optional[Path],
+    no_progress: bool,
+) -> None:
+    """Recursively convert discovered frame sequences under ROOT to review MP4s."""
+    root = root.resolve()
+    if not root.is_dir():
+        click.echo(f"Error: root directory does not exist: {root}", err=True)
+        sys.exit(1)
+
+    if not output_dir.is_absolute():
+        output_dir = root / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_csv = _resolve_batch_manifest_path(
+        root, output_dir, manifest_csv, "renderkit_batch_manifest.csv"
+    )
+    manifest_jsonl = _resolve_batch_manifest_path(
+        root, output_dir, manifest_jsonl, "renderkit_batch_results.jsonl"
+    )
+    manifest_jsonl.parent.mkdir(parents=True, exist_ok=True)
+    manifest_jsonl.write_text("", encoding="utf-8")
+
+    try:
+        sequences = discover_frame_sequences(root, ext)
+    except ValueError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+
+    processor = RenderKit()
+    records: list[BatchManifestRecord] = []
+    succeeded = 0
+    failed = 0
+    skipped = 0
+    planned_outputs: set[Path] = set()
+
+    for sequence in sequences:
+        output_path = build_safe_output_path(root, output_dir, sequence)
+        output_path = _deduplicate_batch_output_path(output_path, planned_outputs)
+        planned_outputs.add(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if output_path.exists() and not overwrite:
+            record = _batch_record(sequence, output_path, "skipped", output_path.stat().st_size)
+            records.append(record)
+            append_jsonl_manifest(manifest_jsonl, record)
+            skipped += 1
+            click.echo(f"Skipped existing: {output_path}")
+            continue
+
+        try:
+            config = _build_batch_conversion_config(
+                input_pattern=str(sequence.input_pattern),
+                output_path=str(output_path),
+                prefetch_workers=prefetch_workers,
+                fps=fps,
+                color_space=color_space,
+                width=width,
+                height=height,
+                codec=codec,
+                quality=quality,
+                layer=layer,
+            )
+            processor.convert_with_config(config, show_progress=False if no_progress else None)
+            size_bytes = output_path.stat().st_size if output_path.exists() else None
+            record = _batch_record(sequence, output_path, "success", size_bytes)
+            succeeded += 1
+            click.echo(f"Converted: {sequence.input_pattern} -> {output_path}")
+        except (RenderKitError, OSError, RuntimeError, ValueError) as exc:
+            logger.exception("Batch conversion failed for %s", sequence.input_pattern)
+            record = _batch_record(sequence, output_path, "failed", None, str(exc))
+            failed += 1
+            click.echo(f"Failed: {sequence.input_pattern}: {exc}", err=True)
+
+        records.append(record)
+        append_jsonl_manifest(manifest_jsonl, record)
+
+    write_csv_manifest(manifest_csv, records)
+
+    click.echo(
+        "Batch complete: "
+        f"{succeeded} succeeded, {failed} failed, {skipped} skipped. "
+        f"CSV: {manifest_csv} JSONL: {manifest_jsonl}"
+    )
+
+    if failed:
+        sys.exit(1)
+
+
+def _resolve_batch_manifest_path(
+    root: Path, output_dir: Path, manifest_path: Optional[Path], default_name: str
+) -> Path:
+    if manifest_path is None:
+        return output_dir / default_name
+    if manifest_path.is_absolute():
+        return manifest_path
+    return root / manifest_path
+
+
+def _deduplicate_batch_output_path(output_path: Path, planned_outputs: set[Path]) -> Path:
+    if output_path not in planned_outputs:
+        return output_path
+
+    index = 2
+    while True:
+        candidate = output_path.with_name(f"{output_path.stem}_{index}{output_path.suffix}")
+        if candidate not in planned_outputs:
+            return candidate
+        index += 1
+
+
+def _build_batch_conversion_config(
+    input_pattern: str,
+    output_path: str,
+    prefetch_workers: int,
+    fps: Optional[float],
+    color_space: str,
+    width: Optional[int],
+    height: Optional[int],
+    codec: str,
+    quality: int,
+    layer: Optional[str],
+) -> ConversionConfig:
+    config_builder = (
+        ConversionConfigBuilder()
+        .with_input_pattern(input_pattern)
+        .with_output_path(output_path)
+        .with_prefetch_workers(prefetch_workers)
+        .with_color_space_preset(COLOR_SPACE_MAP[color_space.lower()])
+        .with_codec(codec)
+        .with_quality(quality)
+        .with_layer(layer)
+    )
+
+    if fps is not None:
+        config_builder.with_fps(fps)
+
+    if width is not None and height is not None:
+        config_builder.with_resolution(width, height)
+
+    return config_builder.build()
+
+
+def _batch_record(
+    sequence: BatchSequence,
+    output_path: Path,
+    status: str,
+    size_bytes: Optional[int],
+    error: str = "",
+) -> BatchManifestRecord:
+    return BatchManifestRecord(
+        input_pattern=str(sequence.input_pattern),
+        output_path=str(output_path),
+        frame_count=sequence.frame_count,
+        frame_range=sequence.frame_range,
+        size_bytes=size_bytes,
+        status=status,
+        error=error,
+    )
 
 
 @main.command()

--- a/src/renderkit/core/batch.py
+++ b/src/renderkit/core/batch.py
@@ -1,0 +1,146 @@
+"""Batch sequence discovery and manifest helpers."""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class BatchSequence:
+    """A frame sequence discovered from a directory scan."""
+
+    directory: Path
+    prefix: str
+    suffix: str
+    padding: int
+    frame_numbers: list[int]
+
+    @property
+    def pattern(self) -> str:
+        return f"{self.prefix}%0{self.padding}d{self.suffix}"
+
+    @property
+    def input_pattern(self) -> Path:
+        return self.directory / self.pattern
+
+    @property
+    def frame_count(self) -> int:
+        return len(self.frame_numbers)
+
+    @property
+    def frame_range(self) -> str:
+        return f"{self.frame_numbers[0]}-{self.frame_numbers[-1]}"
+
+
+@dataclass
+class BatchManifestRecord:
+    """A manifest row for a batch conversion attempt."""
+
+    input_pattern: str
+    output_path: str
+    frame_count: int
+    frame_range: str
+    size_bytes: Optional[int]
+    status: str
+    error: str = ""
+
+    def as_dict(self) -> dict[str, str | int]:
+        return {
+            "input_pattern": self.input_pattern,
+            "output_path": self.output_path,
+            "frame_count": self.frame_count,
+            "frame_range": self.frame_range,
+            "size_bytes": "" if self.size_bytes is None else self.size_bytes,
+            "status": self.status,
+            "error": self.error,
+        }
+
+
+def discover_frame_sequences(root: Path, extension: str) -> list[BatchSequence]:
+    """Recursively discover frame sequences with a numeric frame component."""
+    normalized_ext = _normalize_extension(extension)
+    groups: dict[tuple[Path, str, str, int], set[int]] = {}
+
+    for frame_path in sorted(root.rglob("*")):
+        if not frame_path.is_file() or frame_path.suffix.lower() != normalized_ext:
+            continue
+
+        match = re.match(r"^(?P<prefix>.*?)(?P<frame>\d+)(?P<suffix>\.[^.]+)$", frame_path.name)
+        if not match:
+            continue
+
+        frame_text = match.group("frame")
+        key = (
+            frame_path.parent,
+            match.group("prefix"),
+            match.group("suffix"),
+            len(frame_text),
+        )
+        groups.setdefault(key, set()).add(int(frame_text))
+
+    sequences = [
+        BatchSequence(
+            directory=directory,
+            prefix=prefix,
+            suffix=suffix,
+            padding=padding,
+            frame_numbers=sorted(frame_numbers),
+        )
+        for (directory, prefix, suffix, padding), frame_numbers in groups.items()
+        if frame_numbers
+    ]
+    return sorted(sequences, key=lambda seq: (seq.directory.as_posix(), seq.pattern))
+
+
+def build_safe_output_path(root: Path, output_dir: Path, sequence: BatchSequence) -> Path:
+    """Build a stable collision-resistant MP4 path for a discovered sequence."""
+    relative_dir = sequence.directory.resolve().relative_to(root.resolve())
+    name_parts = [part for part in relative_dir.parts if part not in ("", ".")]
+    stem = sequence.prefix.rstrip("._- ") or "sequence"
+    name_parts.append(stem)
+    safe_name = "_".join(_safe_filename_part(part) for part in name_parts)
+    return output_dir / f"{safe_name}.mp4"
+
+
+def write_csv_manifest(path: Path, records: list[BatchManifestRecord]) -> None:
+    """Write a CSV manifest for all attempted batch conversions."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "input_pattern",
+        "output_path",
+        "frame_count",
+        "frame_range",
+        "size_bytes",
+        "status",
+        "error",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for record in records:
+            writer.writerow(record.as_dict())
+
+
+def append_jsonl_manifest(path: Path, record: BatchManifestRecord) -> None:
+    """Append one JSONL manifest record."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record.as_dict()) + "\n")
+
+
+def _normalize_extension(extension: str) -> str:
+    ext = extension.strip().lower()
+    if not ext:
+        raise ValueError("Extension cannot be empty")
+    return ext if ext.startswith(".") else f".{ext}"
+
+
+def _safe_filename_part(value: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", value.strip())
+    safe = safe.strip("._-")
+    return safe or "sequence"

--- a/src/renderkit/core/batch.py
+++ b/src/renderkit/core/batch.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import csv
 import json
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -70,15 +69,15 @@ def discover_frame_sequences(root: Path, extension: str) -> list[BatchSequence]:
         if not frame_path.is_file() or frame_path.suffix.lower() != normalized_ext:
             continue
 
-        match = re.match(r"^(?P<prefix>.*?)(?P<frame>\d+)(?P<suffix>\.[^.]+)$", frame_path.name)
-        if not match:
+        parsed_name = _split_frame_name(frame_path)
+        if parsed_name is None:
             continue
 
-        frame_text = match.group("frame")
+        prefix, frame_text, suffix = parsed_name
         key = (
             frame_path.parent,
-            match.group("prefix"),
-            match.group("suffix"),
+            prefix,
+            suffix,
             len(frame_text),
         )
         groups.setdefault(key, set()).add(int(frame_text))
@@ -140,7 +139,22 @@ def _normalize_extension(extension: str) -> str:
     return ext if ext.startswith(".") else f".{ext}"
 
 
+def _split_frame_name(frame_path: Path) -> Optional[tuple[str, str, str]]:
+    suffix = frame_path.suffix
+    stem = frame_path.name[: -len(suffix)]
+    frame_start = len(stem)
+    while frame_start > 0 and stem[frame_start - 1].isdigit():
+        frame_start -= 1
+
+    if frame_start == len(stem):
+        return None
+
+    return stem[:frame_start], stem[frame_start:], suffix
+
+
 def _safe_filename_part(value: str) -> str:
-    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", value.strip())
-    safe = safe.strip("._-")
+    safe = "".join(
+        character if character.isascii() and (character.isalnum() or character in "._-") else "_"
+        for character in value.strip()
+    ).strip("._-")
     return safe or "sequence"

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,204 @@
+"""Tests for batch sequence discovery and conversion orchestration."""
+
+import csv
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from renderkit.cli import main as cli_main
+from renderkit.core.batch import build_safe_output_path, discover_frame_sequences
+
+
+def test_discover_frame_sequences_groups_nested_sparse_and_single_frames(
+    tmp_path: Path,
+) -> None:
+    """Batch discovery groups by directory, prefix, suffix, and padding."""
+    for frame in [1001, 1003, 1004]:
+        (tmp_path / "shot_a").mkdir(exist_ok=True)
+        (tmp_path / "shot_a" / f"beauty.{frame:04d}.exr").touch()
+
+    single_dir = tmp_path / "shot_b" / "plates"
+    single_dir.mkdir(parents=True)
+    (single_dir / "plate.007.exr").touch()
+    (single_dir / "notes.txt").touch()
+
+    sequences = discover_frame_sequences(tmp_path, "exr")
+
+    assert [sequence.pattern for sequence in sequences] == [
+        "beauty.%04d.exr",
+        "plate.%03d.exr",
+    ]
+    assert sequences[0].frame_numbers == [1001, 1003, 1004]
+    assert sequences[0].frame_range == "1001-1004"
+    assert sequences[1].frame_numbers == [7]
+    assert sequences[1].frame_range == "7-7"
+
+
+def test_build_safe_output_path_uses_relative_directory_for_collisions(tmp_path: Path) -> None:
+    """Output names include relative folders so repeated sequence stems do not collide."""
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    (tmp_path / "a" / "render.0001.exr").touch()
+    (tmp_path / "b" / "render.0001.exr").touch()
+
+    sequences = discover_frame_sequences(tmp_path, "exr")
+    output_dir = tmp_path / "_review_mp4s"
+    output_paths = [
+        build_safe_output_path(tmp_path, output_dir, sequence) for sequence in sequences
+    ]
+
+    assert output_paths == [
+        output_dir / "a_render.mp4",
+        output_dir / "b_render.mp4",
+    ]
+
+
+def test_discover_frame_sequences_matches_extension_case_insensitively(tmp_path: Path) -> None:
+    """Lowercase --ext values still discover uppercase frame extensions."""
+    (tmp_path / "render.0001.EXR").touch()
+
+    sequences = discover_frame_sequences(tmp_path, "exr")
+
+    assert len(sequences) == 1
+    assert sequences[0].pattern == "render.%04d.EXR"
+
+
+def test_batch_convert_continues_after_failure_and_writes_manifests(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A failed sequence is recorded without stopping later conversions."""
+    good_dir = tmp_path / "good"
+    bad_dir = tmp_path / "bad"
+    later_dir = tmp_path / "later"
+    good_dir.mkdir()
+    bad_dir.mkdir()
+    later_dir.mkdir()
+
+    for frame in [1, 2]:
+        (good_dir / f"beauty.{frame:04d}.exr").touch()
+    (bad_dir / "broken.0001.exr").touch()
+    (later_dir / "plate.007.exr").touch()
+
+    calls: list[str] = []
+
+    class FakeRenderKit:
+        def convert_with_config(self, config, show_progress=None) -> None:
+            calls.append(Path(config.input_pattern).name)
+            if "broken" in config.input_pattern:
+                raise RuntimeError("simulated conversion failure")
+            Path(config.output_path).write_bytes(b"mp4")
+
+    monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
+    monkeypatch.setattr(cli_main, "setup_logging", lambda: None)
+    monkeypatch.setattr(cli_main, "RenderKit", FakeRenderKit)
+
+    result = CliRunner().invoke(
+        cli_main.main,
+        [
+            "batch-convert",
+            str(tmp_path),
+            "--ext",
+            "exr",
+            "--out",
+            "_review_mp4s",
+            "--fps",
+            "24",
+            "--no-progress",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert calls == ["broken.%04d.exr", "beauty.%04d.exr", "plate.%03d.exr"]
+    assert "Batch complete: 2 succeeded, 1 failed, 0 skipped" in result.output
+
+    csv_path = tmp_path / "_review_mp4s" / "renderkit_batch_manifest.csv"
+    jsonl_path = tmp_path / "_review_mp4s" / "renderkit_batch_results.jsonl"
+    with csv_path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    jsonl_rows = [json.loads(line) for line in jsonl_path.read_text(encoding="utf-8").splitlines()]
+
+    assert [row["status"] for row in rows] == ["failed", "success", "success"]
+    assert [row["status"] for row in jsonl_rows] == ["failed", "success", "success"]
+    assert rows[0]["frame_count"] == "1"
+    assert rows[1]["frame_range"] == "1-2"
+    assert rows[2]["size_bytes"] == "3"
+
+
+def test_batch_convert_skips_existing_outputs_without_overwrite(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Existing outputs are manifest-recorded as skipped unless --overwrite is set."""
+    shot_dir = tmp_path / "shot"
+    shot_dir.mkdir()
+    (shot_dir / "render.0001.exr").touch()
+
+    output_dir = tmp_path / "_review_mp4s"
+    output_dir.mkdir()
+    existing_output = output_dir / "shot_render.mp4"
+    existing_output.write_bytes(b"existing")
+
+    class FakeRenderKit:
+        def convert_with_config(self, config, show_progress=None) -> None:
+            raise AssertionError("conversion should not run for skipped output")
+
+    monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
+    monkeypatch.setattr(cli_main, "setup_logging", lambda: None)
+    monkeypatch.setattr(cli_main, "RenderKit", FakeRenderKit)
+
+    result = CliRunner().invoke(
+        cli_main.main,
+        [
+            "batch-convert",
+            str(tmp_path),
+            "--out",
+            "_review_mp4s",
+            "--fps",
+            "24",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "0 succeeded, 0 failed, 1 skipped" in result.output
+
+    csv_path = output_dir / "renderkit_batch_manifest.csv"
+    with csv_path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert rows[0]["status"] == "skipped"
+    assert rows[0]["size_bytes"] == str(len(b"existing"))
+
+
+def test_batch_convert_deduplicates_colliding_output_names(monkeypatch, tmp_path: Path) -> None:
+    """Sequences with the same output stem get distinct MP4 paths."""
+    (tmp_path / "render.001.exr").touch()
+    (tmp_path / "render.0001.exr").touch()
+    output_paths: list[Path] = []
+
+    class FakeRenderKit:
+        def convert_with_config(self, config, show_progress=None) -> None:
+            output_path = Path(config.output_path)
+            output_paths.append(output_path)
+            output_path.write_bytes(b"mp4")
+
+    monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
+    monkeypatch.setattr(cli_main, "setup_logging", lambda: None)
+    monkeypatch.setattr(cli_main, "RenderKit", FakeRenderKit)
+
+    result = CliRunner().invoke(
+        cli_main.main,
+        [
+            "batch-convert",
+            str(tmp_path),
+            "--out",
+            "_review_mp4s",
+            "--fps",
+            "24",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert output_paths == [
+        tmp_path / "_review_mp4s" / "render.mp4",
+        tmp_path / "_review_mp4s" / "render_2.mp4",
+    ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,7 +50,7 @@ def test_convert_exr_sequence_accepts_three_digit_printf_pattern(
     resolved_paths: list[Path] = []
 
     class FakeRenderKit:
-        def convert_with_config(self, config) -> None:
+        def convert_with_config(self, config, show_progress=None) -> None:
             sequence = SequenceDetector.detect_sequence(config.input_pattern)
             resolved_paths.extend(sequence.get_file_path(frame) for frame in sequence.frame_numbers)
             output_path.touch()


### PR DESCRIPTION
## Summary
- add `renderkit batch-convert` for recursive frame sequence discovery and MP4 review output
- write CSV and JSONL manifests with input pattern, output path, frame count/range, output size, status, and errors
- continue after per-sequence failures, skip existing outputs unless `--overwrite`, and document the new workflow

Closes #63.

## Review notes
- Checked prior PRs before implementation; #63 was still open and related PRs covered docs, progress control, or replacement cleanup rather than batch conversion.
- Fixed a review finding so `--ext exr` discovers uppercase `.EXR` files on case-sensitive filesystems.

## Validation
- `uv --system-certs run --extra dev ruff check .`
- `uv --system-certs run --extra dev ruff format --check src\\renderkit\\core\\batch.py src\\renderkit\\cli\\main.py tests\\test_batch.py tests\\test_cli.py`
- `uv --system-certs run --extra dev pytest tests\\test_batch.py tests\\test_cli.py -q`