### PR TITLE
[codex] Harden OCIO and FPS exception handling

### DIFF
--- a/src/renderkit/core/sequence.py
+++ b/src/renderkit/core/sequence.py
@@ -1,10 +1,13 @@
 """Sequence detection and parsing for frame sequences."""
 
+import logging
 import re
 from pathlib import Path
 from typing import Optional
 
-from renderkit.exceptions import SequenceDetectionError
+from renderkit.exceptions import ImageReadError, SequenceDetectionError
+
+logger = logging.getLogger(__name__)
 
 
 class FrameSequence:
@@ -255,9 +258,10 @@ class SequenceDetector:
                 fps = reader.get_metadata_fps(sample_path)
                 if fps is not None:
                     return round(fps, 3)  # Round to avoid precision issues (e.g. 23.976)
-            except Exception:
-                # Silently fail for metadata detection
-                pass
+            except ImportError as exc:
+                logger.warning("FPS metadata detection unavailable for %s: %s", sample_path, exc)
+            except ImageReadError as exc:
+                logger.warning("FPS metadata detection failed for %s: %s", sample_path, exc)
 
         # 2. Return default or None
         return default_fps

--- a/src/renderkit/processing/color_space.py
+++ b/src/renderkit/processing/color_space.py
@@ -326,16 +326,16 @@ class OCIOColorSpaceStrategy:
                         resolved = self.config.getRoleColorSpace(role)
                         if resolved:
                             return resolved
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("Failed to resolve OCIO input role '%s': %s", input_space, exc)
 
         try:
             if hasattr(self.config, "getColorSpaceNameByRole"):
                 resolved = self.config.getColorSpaceNameByRole(input_space)
                 if resolved:
                     return resolved
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("Failed to resolve OCIO role via OIIO API '%s': %s", input_space, exc)
 
         return input_space
 
@@ -396,24 +396,24 @@ class OCIOColorSpaceStrategy:
             major = self.config.getMajorVersion()
             minor = self.config.getMinorVersion()
             config_version = f"{major}.{minor}"
-        except Exception:
-            pass
+        except Exception as exc:
+            config_version = f"unavailable: {exc}"
 
         try:
             search_path = str(self.config.getSearchPath())
-        except Exception:
-            pass
+        except Exception as exc:
+            search_path = f"unavailable: {exc}"
 
         try:
             colorspaces = sorted(self.config.getColorSpaceNames())
-        except Exception:
-            pass
+        except Exception as exc:
+            colorspaces = [f"unavailable: {exc}"]
 
         try:
             role_names = sorted(self.config.getRoleNames())
             roles = [f"{role}={self.config.getRoleColorSpace(role)}" for role in role_names]
-        except Exception:
-            pass
+        except Exception as exc:
+            roles = [f"unavailable: {exc}"]
 
         try:
             default_display = str(self.config.getDefaultDisplay())
@@ -421,8 +421,8 @@ class OCIOColorSpaceStrategy:
             display_view_space = str(
                 self.config.getDisplayViewColorSpaceName(default_display, default_view)
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            default_display = f"unavailable: {exc}"
 
         if resolved_input_space and resolved_output_space:
             try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,7 +50,7 @@ def test_convert_exr_sequence_accepts_three_digit_printf_pattern(
     resolved_paths: list[Path] = []
 
     class FakeRenderKit:
-        def convert_with_config(self, config) -> None:
+        def convert_with_config(self, config, show_progress=None) -> None:
             sequence = SequenceDetector.detect_sequence(config.input_pattern)
             resolved_paths.extend(sequence.get_file_path(frame) for frame in sequence.frame_numbers)
             output_path.touch()

--- a/tests/test_color_space.py
+++ b/tests/test_color_space.py
@@ -1,5 +1,8 @@
 """Tests for color space conversion."""
 
+import logging
+from unittest.mock import Mock
+
 import numpy as np
 import pytest
 
@@ -8,6 +11,7 @@ from renderkit.processing.color_space import (
     ColorSpaceError,
     ColorSpacePreset,
     NoConversionStrategy,
+    OCIOColorSpaceStrategy,
 )
 
 try:
@@ -130,6 +134,56 @@ class TestNoConversionStrategy:
         result = _buf_to_array(result_buf)
 
         np.testing.assert_array_equal(test_image, result)
+
+
+class TestOCIOColorSpaceStrategyDiagnostics:
+    """Tests for OCIO fallback diagnostics."""
+
+    def test_resolve_input_space_logs_role_resolution_failures(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test role API failures are visible while preserving fallback behavior."""
+
+        strategy = object.__new__(OCIOColorSpaceStrategy)
+        strategy.config = Mock()
+        strategy.config.getColorSpaceNames.return_value = ["ACEScg"]
+        strategy.config.hasRole.return_value = True
+        strategy.config.getRoleColorSpace.side_effect = RuntimeError("role API drift")
+        strategy.config.getColorSpaceNameByRole.side_effect = RuntimeError("OIIO role API drift")
+
+        with caplog.at_level(logging.DEBUG, logger="renderkit.processing.color_space"):
+            resolved = strategy._resolve_input_space("scene_linear")
+
+        assert resolved == "scene_linear"
+        assert "Failed to resolve OCIO input role" in caplog.text
+        assert "Failed to resolve OCIO role via OIIO API" in caplog.text
+
+    def test_failure_diagnostics_records_unavailable_probe_values(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test diagnostic probe failures are captured in the final log."""
+
+        strategy = object.__new__(OCIOColorSpaceStrategy)
+        strategy.config = Mock()
+        strategy.config.getMajorVersion.side_effect = RuntimeError("version unavailable")
+        strategy.config.getSearchPath.side_effect = RuntimeError("search path unavailable")
+        strategy.config.getColorSpaceNames.side_effect = RuntimeError("colorspaces unavailable")
+        strategy.config.getRoleNames.side_effect = RuntimeError("roles unavailable")
+        strategy.config.getDefaultDisplay.side_effect = RuntimeError("display unavailable")
+
+        with caplog.at_level(logging.ERROR, logger="renderkit.processing.color_space"):
+            strategy._log_ocio_failure_diagnostics(
+                requested_input_space="scene_linear",
+                resolved_input_space=None,
+                resolved_output_space=None,
+                error=RuntimeError("conversion failed"),
+            )
+
+        assert "config_version=unavailable: version unavailable" in caplog.text
+        assert "search_path=unavailable: search path unavailable" in caplog.text
+        assert "colorspaces_sample=['unavailable: colorspaces unavailable']" in caplog.text
+        assert "roles=['unavailable: roles unavailable']" in caplog.text
+        assert "default_display=unavailable: display unavailable" in caplog.text
 
 
 def _has_oiio_colorspace_candidates(candidates: list[str]) -> bool:

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,11 +1,12 @@
 """Tests for sequence detection and parsing."""
 
+import logging
 from pathlib import Path
 
 import pytest
 
 from renderkit.core.sequence import FrameSequence, SequenceDetector
-from renderkit.exceptions import SequenceDetectionError
+from renderkit.exceptions import ImageReadError, SequenceDetectionError
 
 
 class TestSequenceDetector:
@@ -120,6 +121,49 @@ class TestSequenceDetector:
             tmp_path / "render.003.exr",
         ]
         assert all(path.exists() for path in paths)
+
+    def test_auto_detect_fps_logs_metadata_read_failures(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test FPS metadata read failures do not disappear silently."""
+        sample_path = tmp_path / "render.0001.exr"
+        sample_path.touch()
+
+        class FailingReader:
+            def get_metadata_fps(self, path: Path) -> float:
+                raise ImageReadError("metadata read failed")
+
+        monkeypatch.setattr("renderkit.io.oiio_cache.get_shared_image_cache", lambda: object())
+        monkeypatch.setattr(
+            "renderkit.io.image_reader.ImageReaderFactory.create_reader",
+            lambda path, image_cache=None: FailingReader(),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="renderkit.core.sequence"):
+            fps = SequenceDetector.auto_detect_fps([1], default_fps=24.0, sample_path=sample_path)
+
+        assert fps == pytest.approx(24.0)
+        assert "FPS metadata detection failed" in caplog.text
+
+    def test_auto_detect_fps_propagates_unexpected_metadata_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test unexpected reader bugs are not hidden as missing FPS metadata."""
+        sample_path = tmp_path / "render.0001.exr"
+        sample_path.touch()
+
+        class BrokenReader:
+            def get_metadata_fps(self, path: Path) -> float:
+                raise RuntimeError("reader API drift")
+
+        monkeypatch.setattr("renderkit.io.oiio_cache.get_shared_image_cache", lambda: object())
+        monkeypatch.setattr(
+            "renderkit.io.image_reader.ImageReaderFactory.create_reader",
+            lambda path, image_cache=None: BrokenReader(),
+        )
+
+        with pytest.raises(RuntimeError, match="reader API drift"):
+            SequenceDetector.auto_detect_fps([1], default_fps=24.0, sample_path=sample_path)
 
 
 class TestFrameSequence:


### PR DESCRIPTION
## Summary
- narrow FPS metadata fallback handling to expected import/read failures and log those cases
- surface OCIO role-resolution and diagnostic probe failures in logs instead of silently dropping them
- add regression tests for FPS metadata probing, OCIO diagnostics, and update the stale CLI test double for the current progress API

Closes #75

## Validation
- uv --native-tls run --extra dev ruff check src/renderkit/core/sequence.py src/renderkit/processing/color_space.py tests/test_sequence.py tests/test_color_space.py tests/test_cli.py
- uv --native-tls run --extra dev pytest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * FPS metadata detection now logs warnings when metadata reading fails or is unavailable instead of silently failing
  * Color space configuration resolution provides enhanced diagnostic details when configuration queries encounter errors

* **Tests**
  * Added test coverage for FPS detection error scenarios
  * Added test coverage for color space diagnostic logging behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->