### PR TITLE
Remove stale credit

### DIFF
--- a/src/renderkit/ui/stylesheets/matcha.qss
+++ b/src/renderkit/ui/stylesheets/matcha.qss
@@ -4,7 +4,6 @@
  * Copyright © 2026 Lecoq Simon (@lowlighter)
  * MIT license — https://github.com/lowlighter/matcha
  *
- * Adapted for Qt/QSS by Antigravity
  */
 
 /* ============================================================================


### PR DESCRIPTION
## Summary
- Remove the stale adaptation credit from the Matcha QSS stylesheet header.

