### PR TITLE
Refactor batch CLI command into dedicated module

### DIFF
--- a/src/renderkit/cli/batch.py
+++ b/src/renderkit/cli/batch.py
@@ -1,0 +1,306 @@
+"""Batch conversion CLI command."""
+
+import logging
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Optional, TypeVar
+
+import click
+
+from renderkit.api.processor import RenderKit
+from renderkit.cli.conversion import base_conversion_config_builder
+from renderkit.core.batch import (
+    BatchManifestRecord,
+    BatchSequence,
+    append_jsonl_manifest,
+    build_safe_output_path,
+    discover_frame_sequences,
+    write_csv_manifest,
+)
+from renderkit.core.config import ConversionConfig
+from renderkit.exceptions import RenderKitError
+
+logger = logging.getLogger("renderkit.cli.batch")
+
+F = TypeVar("F", bound=Callable[..., Any])
+ClickOptionSpec = tuple[tuple[str, ...], dict[str, Any]]
+
+
+BATCH_CONVERT_OPTIONS: tuple[ClickOptionSpec, ...] = (
+    (
+        ("--ext",),
+        {"type": str, "default": "exr", "show_default": True, "help": "Input frame extension."},
+    ),
+    (
+        ("--out", "output_dir"),
+        {
+            "type": click.Path(path_type=Path),
+            "default": Path("_review_mp4s"),
+            "show_default": True,
+            "help": "Output directory for generated MP4 files.",
+        },
+    ),
+    (
+        ("--prefetch-workers",),
+        {
+            "type": int,
+            "default": 2,
+            "show_default": True,
+            "help": "Number of frame prefetch workers (set to 1 to disable).",
+        },
+    ),
+    (
+        ("--fps",),
+        {
+            "type": float,
+            "default": None,
+            "help": "Frame rate (fps). If not provided, will attempt auto-detection per sequence.",
+        },
+    ),
+    (
+        ("--color-space",),
+        {
+            "type": click.Choice(
+                ["linear_to_srgb", "linear_to_rec709", "srgb_to_linear", "no_conversion"],
+                case_sensitive=False,
+            ),
+            "default": "linear_to_srgb",
+            "help": "Color space conversion preset (default: linear_to_srgb)",
+        },
+    ),
+    (("--width",), {"type": int, "default": None, "help": "Output width (default: source width)"}),
+    (
+        ("--height",),
+        {"type": int, "default": None, "help": "Output height (default: source height)"},
+    ),
+    (
+        ("--codec",),
+        {
+            "type": str,
+            "default": "libx264",
+            "help": "Video codec (default: libx264, use 'libaom-av1' for AV1)",
+        },
+    ),
+    (
+        ("--quality",),
+        {
+            "type": click.IntRange(0, 10),
+            "default": 10,
+            "help": "Video quality (0-10), 10 is best (default: 10). Sets CRF.",
+        },
+    ),
+    (
+        ("--layer",),
+        {"type": str, "default": None, "help": "Specific EXR layer to extract (e.g., 'diffuse')."},
+    ),
+    (
+        ("--overwrite",),
+        {"is_flag": True, "default": False, "help": "Overwrite output files if they exist."},
+    ),
+    (
+        ("--manifest-csv",),
+        {
+            "type": click.Path(path_type=Path),
+            "default": None,
+            "help": "CSV manifest path (default: OUTPUT_DIR/renderkit_batch_manifest.csv).",
+        },
+    ),
+    (
+        ("--manifest-jsonl",),
+        {
+            "type": click.Path(path_type=Path),
+            "default": None,
+            "help": "JSONL results path (default: OUTPUT_DIR/renderkit_batch_results.jsonl).",
+        },
+    ),
+    (
+        ("--no-progress",),
+        {
+            "is_flag": True,
+            "default": False,
+            "help": "Disable progress bars for stable captured logs.",
+        },
+    ),
+)
+
+
+def _apply_click_options(option_specs: tuple[ClickOptionSpec, ...]) -> Callable[[F], F]:
+    def decorator(func: F) -> F:
+        decorated = func
+        for param_decls, attrs in reversed(option_specs):
+            decorated = click.option(*param_decls, **attrs)(decorated)
+        return decorated
+
+    return decorator
+
+
+@click.command(name="batch-convert")
+@click.argument("root", type=click.Path(path_type=Path))
+@_apply_click_options(BATCH_CONVERT_OPTIONS)
+def batch_convert(
+    root: Path,
+    ext: str,
+    output_dir: Path,
+    prefetch_workers: int,
+    fps: Optional[float],
+    color_space: str,
+    width: Optional[int],
+    height: Optional[int],
+    codec: str,
+    quality: int,
+    layer: Optional[str],
+    overwrite: bool,
+    manifest_csv: Optional[Path],
+    manifest_jsonl: Optional[Path],
+    no_progress: bool,
+) -> None:
+    """Recursively convert discovered frame sequences under ROOT to review MP4s."""
+    root = root.resolve()
+    if not root.is_dir():
+        click.echo(f"Error: root directory does not exist: {root}", err=True)
+        sys.exit(1)
+
+    if not output_dir.is_absolute():
+        output_dir = root / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_csv = _resolve_batch_manifest_path(
+        root, output_dir, manifest_csv, "renderkit_batch_manifest.csv"
+    )
+    manifest_jsonl = _resolve_batch_manifest_path(
+        root, output_dir, manifest_jsonl, "renderkit_batch_results.jsonl"
+    )
+    manifest_jsonl.parent.mkdir(parents=True, exist_ok=True)
+    manifest_jsonl.write_text("", encoding="utf-8")
+
+    try:
+        sequences = discover_frame_sequences(root, ext)
+    except ValueError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+
+    processor = RenderKit()
+    records: list[BatchManifestRecord] = []
+    succeeded = 0
+    failed = 0
+    skipped = 0
+    planned_outputs: set[Path] = set()
+
+    for sequence in sequences:
+        output_path = build_safe_output_path(root, output_dir, sequence)
+        output_path = _deduplicate_batch_output_path(output_path, planned_outputs)
+        planned_outputs.add(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if output_path.exists() and not overwrite:
+            record = _batch_record(sequence, output_path, "skipped", output_path.stat().st_size)
+            records.append(record)
+            append_jsonl_manifest(manifest_jsonl, record)
+            skipped += 1
+            click.echo(f"Skipped existing: {output_path}")
+            continue
+
+        try:
+            config = _build_batch_conversion_config(
+                input_pattern=str(sequence.input_pattern),
+                output_path=output_path,
+                prefetch_workers=prefetch_workers,
+                fps=fps,
+                color_space=color_space,
+                width=width,
+                height=height,
+                codec=codec,
+                quality=quality,
+                layer=layer,
+            )
+            processor.convert_with_config(config, show_progress=False if no_progress else None)
+            size_bytes = output_path.stat().st_size if output_path.exists() else None
+            record = _batch_record(sequence, output_path, "success", size_bytes)
+            succeeded += 1
+            click.echo(f"Converted: {sequence.input_pattern} -> {output_path}")
+        except (RenderKitError, OSError, RuntimeError, ValueError) as exc:
+            logger.exception("Batch conversion failed for %s", sequence.input_pattern)
+            record = _batch_record(sequence, output_path, "failed", None, str(exc))
+            failed += 1
+            click.echo(f"Failed: {sequence.input_pattern}: {exc}", err=True)
+
+        records.append(record)
+        append_jsonl_manifest(manifest_jsonl, record)
+
+    write_csv_manifest(manifest_csv, records)
+
+    click.echo(
+        "Batch complete: "
+        f"{succeeded} succeeded, {failed} failed, {skipped} skipped. "
+        f"CSV: {manifest_csv} JSONL: {manifest_jsonl}"
+    )
+
+    if failed:
+        sys.exit(1)
+
+
+def _resolve_batch_manifest_path(
+    root: Path, output_dir: Path, manifest_path: Optional[Path], default_name: str
+) -> Path:
+    if manifest_path is None:
+        return output_dir / default_name
+    if manifest_path.is_absolute():
+        return manifest_path
+    return root / manifest_path
+
+
+def _deduplicate_batch_output_path(output_path: Path, planned_outputs: set[Path]) -> Path:
+    if output_path not in planned_outputs:
+        return output_path
+
+    index = 2
+    while True:
+        candidate = output_path.with_name(f"{output_path.stem}_{index}{output_path.suffix}")
+        if candidate not in planned_outputs:
+            return candidate
+        index += 1
+
+
+def _build_batch_conversion_config(
+    input_pattern: str,
+    output_path: str | Path,
+    prefetch_workers: int,
+    fps: Optional[float],
+    color_space: str,
+    width: Optional[int],
+    height: Optional[int],
+    codec: str,
+    quality: int,
+    layer: Optional[str],
+) -> ConversionConfig:
+    return base_conversion_config_builder(
+        input_pattern=input_pattern,
+        output_path=output_path,
+        prefetch_workers=prefetch_workers,
+        fps=fps,
+        color_space=color_space,
+        width=width,
+        height=height,
+        codec=codec,
+        quality=quality,
+        layer=layer,
+    ).build()
+
+
+def _batch_record(
+    sequence: BatchSequence,
+    output_path: Path,
+    status: str,
+    size_bytes: Optional[int],
+    error: str = "",
+) -> BatchManifestRecord:
+    return BatchManifestRecord(
+        input_pattern=str(sequence.input_pattern),
+        output_path=str(output_path),
+        frame_count=sequence.frame_count,
+        frame_range=sequence.frame_range,
+        size_bytes=size_bytes,
+        status=status,
+        error=error,
+    )

--- a/src/renderkit/cli/conversion.py
+++ b/src/renderkit/cli/conversion.py
@@ -1,0 +1,49 @@
+"""Shared conversion helpers for CLI commands."""
+
+from pathlib import Path
+from typing import Optional
+
+from renderkit.core.config import ConversionConfigBuilder
+from renderkit.processing.color_space import ColorSpacePreset
+
+COLOR_SPACE_MAP = {
+    "linear_to_srgb": ColorSpacePreset.LINEAR_TO_SRGB,
+    "linear_to_rec709": ColorSpacePreset.LINEAR_TO_REC709,
+    "srgb_to_linear": ColorSpacePreset.SRGB_TO_LINEAR,
+    "no_conversion": ColorSpacePreset.NO_CONVERSION,
+}
+
+
+def base_conversion_config_builder(
+    input_pattern: str,
+    output_path: str | Path,
+    prefetch_workers: int,
+    fps: Optional[float],
+    color_space: str,
+    width: Optional[int],
+    height: Optional[int],
+    codec: str,
+    quality: int,
+    layer: Optional[str],
+) -> ConversionConfigBuilder:
+    """Build shared conversion settings used by CLI conversion commands."""
+    config_builder = (
+        ConversionConfigBuilder()
+        .with_input_pattern(input_pattern)
+        .with_output_path(str(output_path))
+        .with_prefetch_workers(prefetch_workers)
+        .with_color_space_preset(COLOR_SPACE_MAP[color_space.lower()])
+        .with_codec(codec)
+        .with_quality(quality)
+    )
+
+    if layer is not None:
+        config_builder.with_layer(layer)
+
+    if fps is not None:
+        config_builder.with_fps(fps)
+
+    if width is not None and height is not None:
+        config_builder.with_resolution(width, height)
+
+    return config_builder

--- a/src/renderkit/cli/main.py
+++ b/src/renderkit/cli/main.py
@@ -2,28 +2,19 @@
 
 import logging
 import sys
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Optional, TypeVar
+from typing import Optional
 
 import click
 
 from renderkit import __version__
 from renderkit.api.processor import RenderKit
-from renderkit.core.batch import (
-    BatchManifestRecord,
-    BatchSequence,
-    append_jsonl_manifest,
-    build_safe_output_path,
-    discover_frame_sequences,
-    write_csv_manifest,
-)
+from renderkit.cli.batch import batch_convert
+from renderkit.cli.conversion import base_conversion_config_builder
 from renderkit.core.config import (
     BurnInConfig,
     BurnInElement,
     ContactSheetConfigBuilder,
-    ConversionConfig,
-    ConversionConfigBuilder,
 )
 from renderkit.core.ffmpeg_utils import ensure_ffmpeg_env
 from renderkit.core.profiler import get_profile_env_config, profile_context
@@ -34,128 +25,8 @@ from renderkit.core.sequence_replacement import (
 )
 from renderkit.exceptions import RenderKitError
 from renderkit.logging_utils import setup_logging
-from renderkit.processing.color_space import ColorSpacePreset
 
 logger = logging.getLogger("renderkit.cli.main")
-
-
-COLOR_SPACE_MAP = {
-    "linear_to_srgb": ColorSpacePreset.LINEAR_TO_SRGB,
-    "linear_to_rec709": ColorSpacePreset.LINEAR_TO_REC709,
-    "srgb_to_linear": ColorSpacePreset.SRGB_TO_LINEAR,
-    "no_conversion": ColorSpacePreset.NO_CONVERSION,
-}
-
-F = TypeVar("F", bound=Callable[..., Any])
-ClickOptionSpec = tuple[tuple[str, ...], dict[str, Any]]
-
-
-BATCH_CONVERT_OPTIONS: tuple[ClickOptionSpec, ...] = (
-    (
-        ("--ext",),
-        {"type": str, "default": "exr", "show_default": True, "help": "Input frame extension."},
-    ),
-    (
-        ("--out", "output_dir"),
-        {
-            "type": click.Path(path_type=Path),
-            "default": Path("_review_mp4s"),
-            "show_default": True,
-            "help": "Output directory for generated MP4 files.",
-        },
-    ),
-    (
-        ("--prefetch-workers",),
-        {
-            "type": int,
-            "default": 2,
-            "show_default": True,
-            "help": "Number of frame prefetch workers (set to 1 to disable).",
-        },
-    ),
-    (
-        ("--fps",),
-        {
-            "type": float,
-            "default": None,
-            "help": "Frame rate (fps). If not provided, will attempt auto-detection per sequence.",
-        },
-    ),
-    (
-        ("--color-space",),
-        {
-            "type": click.Choice(
-                ["linear_to_srgb", "linear_to_rec709", "srgb_to_linear", "no_conversion"],
-                case_sensitive=False,
-            ),
-            "default": "linear_to_srgb",
-            "help": "Color space conversion preset (default: linear_to_srgb)",
-        },
-    ),
-    (("--width",), {"type": int, "default": None, "help": "Output width (default: source width)"}),
-    (
-        ("--height",),
-        {"type": int, "default": None, "help": "Output height (default: source height)"},
-    ),
-    (
-        ("--codec",),
-        {
-            "type": str,
-            "default": "libx264",
-            "help": "Video codec (default: libx264, use 'libaom-av1' for AV1)",
-        },
-    ),
-    (
-        ("--quality",),
-        {
-            "type": click.IntRange(0, 10),
-            "default": 10,
-            "help": "Video quality (0-10), 10 is best (default: 10). Sets CRF.",
-        },
-    ),
-    (
-        ("--layer",),
-        {"type": str, "default": None, "help": "Specific EXR layer to extract (e.g., 'diffuse')."},
-    ),
-    (
-        ("--overwrite",),
-        {"is_flag": True, "default": False, "help": "Overwrite output files if they exist."},
-    ),
-    (
-        ("--manifest-csv",),
-        {
-            "type": click.Path(path_type=Path),
-            "default": None,
-            "help": "CSV manifest path (default: OUTPUT_DIR/renderkit_batch_manifest.csv).",
-        },
-    ),
-    (
-        ("--manifest-jsonl",),
-        {
-            "type": click.Path(path_type=Path),
-            "default": None,
-            "help": "JSONL results path (default: OUTPUT_DIR/renderkit_batch_results.jsonl).",
-        },
-    ),
-    (
-        ("--no-progress",),
-        {
-            "is_flag": True,
-            "default": False,
-            "help": "Disable progress bars for stable captured logs.",
-        },
-    ),
-)
-
-
-def _apply_click_options(option_specs: tuple[ClickOptionSpec, ...]) -> Callable[[F], F]:
-    def decorator(func: F) -> F:
-        decorated = func
-        for param_decls, attrs in reversed(option_specs):
-            decorated = click.option(*param_decls, **attrs)(decorated)
-        return decorated
-
-    return decorator
 
 
 @click.group()
@@ -339,7 +210,7 @@ def convert_exr_sequence(
         sys.exit(1)
 
     # Build configuration
-    config_builder = _base_conversion_config_builder(
+    config_builder = base_conversion_config_builder(
         input_pattern=input_pattern,
         output_path=output_path,
         prefetch_workers=prefetch_workers,
@@ -415,209 +286,7 @@ def convert_exr_sequence(
         sys.exit(1)
 
 
-@main.command(name="batch-convert")
-@click.argument("root", type=click.Path(path_type=Path))
-@_apply_click_options(BATCH_CONVERT_OPTIONS)
-def batch_convert(
-    root: Path,
-    ext: str,
-    output_dir: Path,
-    prefetch_workers: int,
-    fps: Optional[float],
-    color_space: str,
-    width: Optional[int],
-    height: Optional[int],
-    codec: str,
-    quality: int,
-    layer: Optional[str],
-    overwrite: bool,
-    manifest_csv: Optional[Path],
-    manifest_jsonl: Optional[Path],
-    no_progress: bool,
-) -> None:
-    """Recursively convert discovered frame sequences under ROOT to review MP4s."""
-    root = root.resolve()
-    if not root.is_dir():
-        click.echo(f"Error: root directory does not exist: {root}", err=True)
-        sys.exit(1)
-
-    if not output_dir.is_absolute():
-        output_dir = root / output_dir
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    manifest_csv = _resolve_batch_manifest_path(
-        root, output_dir, manifest_csv, "renderkit_batch_manifest.csv"
-    )
-    manifest_jsonl = _resolve_batch_manifest_path(
-        root, output_dir, manifest_jsonl, "renderkit_batch_results.jsonl"
-    )
-    manifest_jsonl.parent.mkdir(parents=True, exist_ok=True)
-    manifest_jsonl.write_text("", encoding="utf-8")
-
-    try:
-        sequences = discover_frame_sequences(root, ext)
-    except ValueError as exc:
-        click.echo(f"Error: {exc}", err=True)
-        sys.exit(1)
-
-    processor = RenderKit()
-    records: list[BatchManifestRecord] = []
-    succeeded = 0
-    failed = 0
-    skipped = 0
-    planned_outputs: set[Path] = set()
-
-    for sequence in sequences:
-        output_path = build_safe_output_path(root, output_dir, sequence)
-        output_path = _deduplicate_batch_output_path(output_path, planned_outputs)
-        planned_outputs.add(output_path)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
-        if output_path.exists() and not overwrite:
-            record = _batch_record(sequence, output_path, "skipped", output_path.stat().st_size)
-            records.append(record)
-            append_jsonl_manifest(manifest_jsonl, record)
-            skipped += 1
-            click.echo(f"Skipped existing: {output_path}")
-            continue
-
-        try:
-            config = _build_batch_conversion_config(
-                input_pattern=str(sequence.input_pattern),
-                output_path=str(output_path),
-                prefetch_workers=prefetch_workers,
-                fps=fps,
-                color_space=color_space,
-                width=width,
-                height=height,
-                codec=codec,
-                quality=quality,
-                layer=layer,
-            )
-            processor.convert_with_config(config, show_progress=False if no_progress else None)
-            size_bytes = output_path.stat().st_size if output_path.exists() else None
-            record = _batch_record(sequence, output_path, "success", size_bytes)
-            succeeded += 1
-            click.echo(f"Converted: {sequence.input_pattern} -> {output_path}")
-        except (RenderKitError, OSError, RuntimeError, ValueError) as exc:
-            logger.exception("Batch conversion failed for %s", sequence.input_pattern)
-            record = _batch_record(sequence, output_path, "failed", None, str(exc))
-            failed += 1
-            click.echo(f"Failed: {sequence.input_pattern}: {exc}", err=True)
-
-        records.append(record)
-        append_jsonl_manifest(manifest_jsonl, record)
-
-    write_csv_manifest(manifest_csv, records)
-
-    click.echo(
-        "Batch complete: "
-        f"{succeeded} succeeded, {failed} failed, {skipped} skipped. "
-        f"CSV: {manifest_csv} JSONL: {manifest_jsonl}"
-    )
-
-    if failed:
-        sys.exit(1)
-
-
-def _resolve_batch_manifest_path(
-    root: Path, output_dir: Path, manifest_path: Optional[Path], default_name: str
-) -> Path:
-    if manifest_path is None:
-        return output_dir / default_name
-    if manifest_path.is_absolute():
-        return manifest_path
-    return root / manifest_path
-
-
-def _deduplicate_batch_output_path(output_path: Path, planned_outputs: set[Path]) -> Path:
-    if output_path not in planned_outputs:
-        return output_path
-
-    index = 2
-    while True:
-        candidate = output_path.with_name(f"{output_path.stem}_{index}{output_path.suffix}")
-        if candidate not in planned_outputs:
-            return candidate
-        index += 1
-
-
-def _base_conversion_config_builder(
-    input_pattern: str,
-    output_path: str,
-    prefetch_workers: int,
-    fps: Optional[float],
-    color_space: str,
-    width: Optional[int],
-    height: Optional[int],
-    codec: str,
-    quality: int,
-    layer: Optional[str],
-) -> ConversionConfigBuilder:
-    config_builder = (
-        ConversionConfigBuilder()
-        .with_input_pattern(input_pattern)
-        .with_output_path(output_path)
-        .with_prefetch_workers(prefetch_workers)
-        .with_color_space_preset(COLOR_SPACE_MAP[color_space.lower()])
-        .with_codec(codec)
-        .with_quality(quality)
-    )
-
-    if layer is not None:
-        config_builder.with_layer(layer)
-
-    if fps is not None:
-        config_builder.with_fps(fps)
-
-    if width is not None and height is not None:
-        config_builder.with_resolution(width, height)
-
-    return config_builder
-
-
-def _build_batch_conversion_config(
-    input_pattern: str,
-    output_path: str,
-    prefetch_workers: int,
-    fps: Optional[float],
-    color_space: str,
-    width: Optional[int],
-    height: Optional[int],
-    codec: str,
-    quality: int,
-    layer: Optional[str],
-) -> ConversionConfig:
-    return _base_conversion_config_builder(
-        input_pattern=input_pattern,
-        output_path=output_path,
-        prefetch_workers=prefetch_workers,
-        fps=fps,
-        color_space=color_space,
-        width=width,
-        height=height,
-        codec=codec,
-        quality=quality,
-        layer=layer,
-    ).build()
-
-
-def _batch_record(
-    sequence: BatchSequence,
-    output_path: Path,
-    status: str,
-    size_bytes: Optional[int],
-    error: str = "",
-) -> BatchManifestRecord:
-    return BatchManifestRecord(
-        input_pattern=str(sequence.input_pattern),
-        output_path=str(output_path),
-        frame_count=sequence.frame_count,
-        frame_range=sequence.frame_range,
-        size_bytes=size_bytes,
-        status=status,
-        error=error,
-    )
+main.add_command(batch_convert)
 
 
 @main.command()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
+from renderkit.cli import batch as cli_batch
 from renderkit.cli import main as cli_main
 from renderkit.core.batch import build_safe_output_path, discover_frame_sequences
 
@@ -91,7 +92,7 @@ def test_batch_convert_continues_after_failure_and_writes_manifests(
 
     monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
     monkeypatch.setattr(cli_main, "setup_logging", lambda: None)
-    monkeypatch.setattr(cli_main, "RenderKit", FakeRenderKit)
+    monkeypatch.setattr(cli_batch, "RenderKit", FakeRenderKit)
 
     result = CliRunner().invoke(
         cli_main.main,
@@ -144,7 +145,7 @@ def test_batch_convert_skips_existing_outputs_without_overwrite(
 
     monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
     monkeypatch.setattr(cli_main, "setup_logging", lambda: None)
-    monkeypatch.setattr(cli_main, "RenderKit", FakeRenderKit)
+    monkeypatch.setattr(cli_batch, "RenderKit", FakeRenderKit)
 
     result = CliRunner().invoke(
         cli_main.main,
@@ -183,7 +184,7 @@ def test_batch_convert_deduplicates_colliding_output_names(monkeypatch, tmp_path
 
     monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
     monkeypatch.setattr(cli_main, "setup_logging", lambda: None)
-    monkeypatch.setattr(cli_main, "RenderKit", FakeRenderKit)
+    monkeypatch.setattr(cli_batch, "RenderKit", FakeRenderKit)
 
     result = CliRunner().invoke(
         cli_main.main,


### PR DESCRIPTION
## Summary
- Move batch-convert Click command, options, and helpers into renderkit.cli.batch
- Move the shared conversion config builder into renderkit.cli.conversion
- Keep main.py focused on command registration and non-batch CLI commands
- Update batch CLI tests to patch the new command module owner

## Tests
- uv run pytest tests\\test_batch.py tests\\test_cli.py
- uv run ruff check src\\renderkit\\cli tests\\test_batch.py tests\\test_cli.py
- uv run ruff format --check src\\renderkit\\cli tests\\test_batch.py tests\\test_cli.py

Closes #76