### PR TITLE
Make mypy usable as a scoped guardrail

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,9 +80,13 @@ uv run ruff format .
 # Lint code
 uv run ruff check .
 
-# Type checking (optional)
-uv run mypy src/
+# Type checking for the current mypy baseline
+uv run --extra dev mypy
 ```
+
+The mypy baseline is intentionally scoped in `pyproject.toml` to CLI, core, and
+public API code. UI and image-processing modules still depend on third-party
+Qt/OIIO/OCIO typing that is being brought under mypy incrementally.
 
 ## Testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,11 @@ omit = [
 
 [tool.mypy]
 python_version = "3.13"
+files = [
+    "src/renderkit/api",
+    "src/renderkit/cli",
+    "src/renderkit/core",
+]
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
@@ -120,6 +125,7 @@ warn_no_return = true
 module = [
     "OpenImageIO.*",
     "opencolorio.*",
+    "tqdm.*",
 ]
 ignore_missing_imports = true
 

--- a/src/renderkit/api/processor.py
+++ b/src/renderkit/api/processor.py
@@ -71,12 +71,16 @@ class RenderKit:
             .with_input_pattern(input_pattern)
             .with_output_path(output_path)
             .with_prefetch_workers(prefetch_workers)
-            .with_fps(fps)
             .with_color_space_preset(color_space_preset)
             .with_codec(codec)
             .with_quality(quality)
-            .with_layer(layer)
         )
+
+        if fps is not None:
+            config.with_fps(fps)
+
+        if layer is not None:
+            config.with_layer(layer)
 
         if width is not None and height is not None:
             config.with_resolution(width, height)

--- a/src/renderkit/cli/main.py
+++ b/src/renderkit/cli/main.py
@@ -3,7 +3,7 @@
 import logging
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import click
 
@@ -14,17 +14,21 @@ from renderkit.cli.conversion import base_conversion_config_builder
 from renderkit.core.config import (
     BurnInConfig,
     BurnInElement,
-    ContactSheetConfigBuilder,
+    ContactSheetConfig,
 )
 from renderkit.core.ffmpeg_utils import ensure_ffmpeg_env
 from renderkit.core.profiler import get_profile_env_config, profile_context
+from renderkit.core.sequence import SequenceDetector
 from renderkit.core.sequence_replacement import (
     find_exr_sequences,
     find_replacement_mp4,
     replace_sequence_with_mp4,
 )
 from renderkit.exceptions import RenderKitError
+from renderkit.io.image_reader import ImageReaderFactory
+from renderkit.io.oiio_cache import get_shared_image_cache
 from renderkit.logging_utils import setup_logging
+from renderkit.processing.scaler import ImageScaler
 
 logger = logging.getLogger("renderkit.cli.main")
 
@@ -43,6 +47,104 @@ def _launch_ui() -> None:
     from renderkit.ui.main_window import run_ui
 
     run_ui()
+
+
+def _label_height(config: ContactSheetConfig) -> int:
+    if not config.show_labels:
+        return 0
+    label_gap = max(4, int(config.font_size * 0.01))
+    return label_gap + int(config.font_size * 1.4)
+
+
+def _to_rgb_buf(oiio: Any, buf: Any) -> Any:
+    spec = buf.spec()
+    if spec.nchannels == 3:
+        return buf
+    if spec.nchannels >= 3:
+        rgb_buf = oiio.ImageBufAlgo.channels(buf, (0, 1, 2), ("R", "G", "B"))
+    elif spec.nchannels == 2:
+        rgb_buf = oiio.ImageBufAlgo.channels(buf, (0, 1, 1), ("R", "G", "B"))
+    else:
+        rgb_buf = oiio.ImageBufAlgo.channels(buf, (0, 0, 0), ("R", "G", "B"))
+    if rgb_buf.has_error:
+        raise RuntimeError(f"Failed to convert contact sheet frame to RGB: {rgb_buf.geterror()}")
+    return rgb_buf
+
+
+def _write_sequence_contact_sheet(
+    input_pattern: str,
+    output_path: Path,
+    config: ContactSheetConfig,
+    layer: Optional[str],
+    start_frame: Optional[int],
+    end_frame: Optional[int],
+) -> None:
+    """Write a still contact sheet made from frames in a sequence."""
+    try:
+        import OpenImageIO as oiio
+    except ImportError as exc:
+        raise RuntimeError("OpenImageIO library not available.") from exc
+
+    sequence = SequenceDetector.detect_sequence(input_pattern)
+    frame_numbers = sequence.frame_numbers
+    if start_frame is not None:
+        frame_numbers = [frame for frame in frame_numbers if frame >= start_frame]
+    if end_frame is not None:
+        frame_numbers = [frame for frame in frame_numbers if frame <= end_frame]
+    if not frame_numbers:
+        raise ValueError("No frames found in specified range")
+
+    first_path = sequence.get_file_path(frame_numbers[0])
+    reader = ImageReaderFactory.create_reader(first_path, image_cache=get_shared_image_cache())
+    first_buf = _to_rgb_buf(oiio, reader.read_imagebuf(first_path, layer=layer))
+    first_spec = first_buf.spec()
+    thumb_w, thumb_h = config.resolve_layer_size(first_spec.width, first_spec.height)
+    padding = config.padding
+    label_h = _label_height(config)
+    label_gap = max(4, int(config.font_size * 0.01)) if config.show_labels else 0
+    cell_w = thumb_w + (padding * 2)
+    cell_h = thumb_h + (padding * 2) + label_h
+    rows = (len(frame_numbers) + config.columns - 1) // config.columns
+
+    canvas_spec = oiio.ImageSpec(cell_w * config.columns, cell_h * rows, 3, oiio.FLOAT)
+    canvas = oiio.ImageBuf(canvas_spec)
+    oiio.ImageBufAlgo.fill(canvas, config.background_color)
+
+    for index, frame_number in enumerate(frame_numbers):
+        frame_path = sequence.get_file_path(frame_number)
+        buf = (
+            first_buf
+            if index == 0
+            else _to_rgb_buf(oiio, reader.read_imagebuf(frame_path, layer=layer))
+        )
+        spec = buf.spec()
+        if spec.width != thumb_w or spec.height != thumb_h:
+            buf = ImageScaler.scale_buf(buf, thumb_w, thumb_h)
+
+        row = index // config.columns
+        col = index % config.columns
+        x_offset = col * cell_w + padding
+        y_offset = row * cell_h + padding
+        if not oiio.ImageBufAlgo.paste(canvas, x_offset, y_offset, 0, 0, buf):
+            raise RuntimeError(f"Failed to paste frame {frame_number}: {oiio.geterror()}")
+
+        if config.show_labels:
+            label_y = y_offset + thumb_h + label_gap + config.font_size
+            if not oiio.ImageBufAlgo.render_text(
+                canvas,
+                x_offset,
+                label_y,
+                str(frame_number),
+                fontsize=config.font_size,
+                textcolor=(1, 1, 1, 1),
+            ):
+                raise RuntimeError(
+                    f"Failed to render frame label {frame_number}: {oiio.geterror()}"
+                )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if not canvas.write(str(output_path)):
+        raise RuntimeError(f"Failed to write contact sheet: {canvas.geterror() or oiio.geterror()}")
 
 
 @main.command(name="ui")
@@ -174,7 +276,7 @@ def convert_exr_sequence(
     burnin_opacity: int,
     contact_sheet: bool,
     cs_columns: int,
-    cs_thumb_width: int,
+    cs_thumb_width: Optional[int],
     cs_padding: int,
     cs_no_labels: bool,
     profile: bool,
@@ -322,7 +424,7 @@ def contact_sheet(
     input_pattern: str,
     output_path: str,
     columns: int,
-    thumb_width: int,
+    thumb_width: Optional[int],
     padding: int,
     no_labels: bool,
     font_size: int,
@@ -345,29 +447,22 @@ def contact_sheet(
         click.echo("Use --overwrite to overwrite it.", err=True)
         sys.exit(1)
 
-    # Build configuration
-    config_builder = (
-        ContactSheetConfigBuilder()
-        .with_input_pattern(input_pattern)
-        .with_output_path(output_path)
-        .with_columns(columns)
-        .with_padding(padding)
-        .with_labels(not no_labels, font_size=font_size)
-    )
-
-    if thumb_width is not None:
-        config_builder = config_builder.with_thumbnail_width(thumb_width)
-
-    if layer:
-        config_builder.with_layer(layer)
-
-    if start_frame is not None and end_frame is not None:
-        config_builder.with_frame_range(start_frame, end_frame)
-
     try:
-        config = config_builder.build()
-        processor = RenderKit()
-        processor.create_contact_sheet(config)
+        config = ContactSheetConfig(
+            columns=columns,
+            thumbnail_width=thumb_width,
+            padding=padding,
+            show_labels=not no_labels,
+            font_size=font_size,
+        )
+        _write_sequence_contact_sheet(
+            input_pattern=input_pattern,
+            output_path=output_path_obj,
+            config=config,
+            layer=layer,
+            start_frame=start_frame,
+            end_frame=end_frame,
+        )
         logger.info(f"Successfully created contact sheet: {output_path}")
         click.echo(f"Successfully created contact sheet: {output_path}")
     except (RenderKitError, OSError, RuntimeError, ValueError) as e:

--- a/src/renderkit/core/config.py
+++ b/src/renderkit/core/config.py
@@ -68,9 +68,11 @@ class ContactSheetConfig:
             target_w = self.thumbnail_width
 
         if target_w is None:
+            assert target_h is not None
             scale = target_h / source_height
             target_w = max(1, int(source_width * scale))
         if target_h is None:
+            assert target_w is not None
             scale = target_w / source_width
             target_h = max(1, int(source_height * scale))
 

--- a/src/renderkit/core/converter.py
+++ b/src/renderkit/core/converter.py
@@ -2,9 +2,10 @@ import logging
 import sys
 import threading
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
-from typing import Optional
+from types import TracebackType
+from typing import Any, Optional
 
 from renderkit.core.config import ConversionConfig
 from renderkit.core.sequence import FrameSequence, SequenceDetector
@@ -16,7 +17,7 @@ from renderkit.exceptions import (
     VideoEncodingError,
 )
 from renderkit.io.file_info import FileInfo
-from renderkit.io.image_reader import ImageReader, ImageReaderFactory
+from renderkit.io.image_reader import ImageReader, ImageReaderFactory, LayerMapEntry
 from renderkit.io.oiio_cache import get_shared_image_cache
 from renderkit.processing.burnin import BurnInProcessor
 from renderkit.processing.color_space import ColorSpaceConverter, ColorSpacePreset
@@ -32,7 +33,7 @@ class _FramePrefetcher:
 
     def __init__(
         self,
-        prefetch_fn: Callable[[int], object],
+        prefetch_fn: Callable[[int], Any],
         frames: list[int],
         max_workers: int,
         thread_name_prefix: str = "renderkit-prefetch",
@@ -44,7 +45,7 @@ class _FramePrefetcher:
             max_workers=max_workers,
             thread_name_prefix=thread_name_prefix,
         )
-        self._pending: dict[int, object] = {}
+        self._pending: dict[int, Future[Any]] = {}
         self._next_index = 0
         self._prime()
 
@@ -60,7 +61,7 @@ class _FramePrefetcher:
         while len(self._pending) < self._max_pending and self._submit_next():
             pass
 
-    def get_future(self, frame_num: int):
+    def get_future(self, frame_num: int) -> Future[Any]:
         future = self._pending.pop(frame_num, None)
         if future is None:
             future = self._executor.submit(self._prefetch_fn, frame_num)
@@ -73,10 +74,15 @@ class _FramePrefetcher:
         except TypeError:
             self._executor.shutdown(wait=True)
 
-    def __enter__(self):
+    def __enter__(self) -> "_FramePrefetcher":
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         self.close()
 
 
@@ -91,12 +97,12 @@ class SequenceConverter:
         """
         self.config = config
         self.sequence: Optional[FrameSequence] = None
-        self.reader = None
+        self.reader: Optional[ImageReader] = None
         self.color_converter: Optional[ColorSpaceConverter] = None
         self.encoder: Optional[VideoEncoder] = None
         self.burnin_processor = BurnInProcessor()
         self.contact_sheet_generator: Optional[ContactSheetGenerator] = None
-        self._layer_map = None
+        self._layer_map: Optional[dict[str, LayerMapEntry]] = None
 
     def convert(
         self,
@@ -185,6 +191,8 @@ class SequenceConverter:
         self, first_frame_num: int
     ) -> tuple[FileInfo, int, int, Optional[str]]:
         """Initialize reader, metadata caches, and contact sheet generator."""
+        if self.sequence is None:
+            raise RuntimeError("Sequence must be detected before initializing the reader.")
         first_frame_path = self.sequence.get_file_path(first_frame_num)
         self.reader = ImageReaderFactory.create_reader(
             first_frame_path, image_cache=get_shared_image_cache()
@@ -227,20 +235,19 @@ class SequenceConverter:
         output_width = self.config.width or width
         output_height = self.config.height or height
 
-        if self.config.contact_sheet_mode and self.contact_sheet_generator:
+        cs_config = self.config.contact_sheet_config
+        if self.config.contact_sheet_mode and self.contact_sheet_generator and cs_config:
             layers = file_info.layers
             if layers:
-                cols = self.config.contact_sheet_config.columns
+                cols = cs_config.columns
                 rows = (len(layers) + cols - 1) // cols
 
-                thumb_w, thumb_h = self.config.contact_sheet_config.resolve_layer_size(
-                    width, height
-                )
+                thumb_w, thumb_h = cs_config.resolve_layer_size(width, height)
 
-                padding = self.config.contact_sheet_config.padding
+                padding = cs_config.padding
                 label_h = 0
-                if self.config.contact_sheet_config.show_labels:
-                    label_h = int(self.config.contact_sheet_config.font_size * 2.5)
+                if cs_config.show_labels:
+                    label_h = int(cs_config.font_size * 2.5)
 
                 cell_w = thumb_w + (padding * 2)
                 cell_h = thumb_h + (padding * 2) + label_h
@@ -271,6 +278,8 @@ class SequenceConverter:
 
     def _initialize_encoder(self, output_width: int, output_height: int) -> None:
         """Initialize the video encoder for output."""
+        if self.config.fps is None:
+            raise ValueError("FPS must be resolved before initializing the encoder.")
         self.encoder = VideoEncoder(
             Path(self.config.output_path),
             self.config.fps,
@@ -294,6 +303,9 @@ class SequenceConverter:
     ) -> None:
         """Process all frames and write them to the encoder."""
         logger.debug(f"Processing {len(frame_numbers)} frames...")
+        if self.sequence is None:
+            raise RuntimeError("Sequence must be detected before processing frames.")
+        sequence = self.sequence
 
         all_frames, existing_frames, start_frame, end_frame, total_frames = self._build_frame_range(
             frame_numbers
@@ -308,15 +320,16 @@ class SequenceConverter:
 
         scaler = ImageScaler()
         success_count = 0
-        last_valid_buf = None
+        last_valid_buf: Any = None
         prefetch_workers = max(1, self.config.prefetch_workers)
-        contact_sheet_enabled = (
-            self.config.contact_sheet_mode and self.config.contact_sheet_config is not None
+        contact_sheet_config = (
+            self.config.contact_sheet_config if self.config.contact_sheet_mode else None
         )
+        contact_sheet_enabled = contact_sheet_config is not None
         if show_progress is None:
             stderr_isatty = getattr(sys.stderr, "isatty", None)
             show_progress = bool(stderr_isatty and stderr_isatty())
-        pbar = None
+        pbar: Any = None
 
         def _tick_progress(current_index: int) -> None:
             if progress_callback:
@@ -336,7 +349,7 @@ class SequenceConverter:
                 thread_state = threading.local()
                 layers_for_cs = file_info.layers if contact_sheet_enabled else None
 
-                def _get_thread_resources(frame_path: Path):
+                def _get_thread_resources(frame_path: Path) -> Any:
                     reader = getattr(thread_state, "reader", None)
                     if reader is None:
                         reader = ImageReaderFactory.create_reader(
@@ -355,8 +368,9 @@ class SequenceConverter:
                     if contact_sheet_enabled and not hasattr(
                         thread_state, "contact_sheet_generator"
                     ):
+                        assert contact_sheet_config is not None
                         thread_state.contact_sheet_generator = ContactSheetGenerator(
-                            self.config.contact_sheet_config,
+                            contact_sheet_config,
                             reader=reader,
                             layers=layers_for_cs,
                             layer_map=self._layer_map,
@@ -364,8 +378,8 @@ class SequenceConverter:
 
                     return thread_state
 
-                def _prefetch_frame(frame_num: int):
-                    frame_path = self.sequence.get_file_path(frame_num)
+                def _prefetch_frame(frame_num: int) -> Any:
+                    frame_path = sequence.get_file_path(frame_num)
                     resources = _get_thread_resources(frame_path)
                     return self._prepare_frame_buf(
                         frame_num,
@@ -445,8 +459,10 @@ class SequenceConverter:
         color_converter: ColorSpaceConverter,
         burnin_processor: Optional[BurnInProcessor],
         contact_sheet_generator: Optional[ContactSheetGenerator] = None,
-    ):
+    ) -> Any:
         """Prepare a single frame buffer without writing it to the encoder."""
+        if self.sequence is None:
+            raise RuntimeError("Sequence must be detected before preparing frames.")
         frame_path = self.sequence.get_file_path(frame_num)
 
         if contact_sheet_generator:
@@ -521,8 +537,10 @@ class SequenceConverter:
         total_frames = len(all_frames)
         return all_frames, existing_frames, start_frame, end_frame, total_frames
 
-    def _write_frame_buf(self, frame_num: int, buf, label: str = "frame") -> None:
+    def _write_frame_buf(self, frame_num: int, buf: Any, label: str = "frame") -> None:
         """Write an ImageBuf to the encoder with consistent error handling."""
+        if self.encoder is None:
+            raise VideoEncodingError("Video encoder is not initialized.")
         try:
             self.encoder.write_frame(buf)
         except VideoEncodingError:
@@ -532,7 +550,7 @@ class SequenceConverter:
             raise VideoEncodingError(f"Failed to write {label} {frame_num}: {e}") from e
 
     def _write_freeze_frame(
-        self, frame_num: int, last_valid_buf, index: int, log_every: int = 10
+        self, frame_num: int, last_valid_buf: Any, index: int, log_every: int = 10
     ) -> bool:
         """Write a freeze-frame if available, otherwise log and skip."""
         if last_valid_buf is None:
@@ -554,8 +572,12 @@ class SequenceConverter:
         scaler: "ImageScaler",
         input_space: Optional[str],
         contact_sheet_generator: Optional[ContactSheetGenerator] = None,
-    ):
+    ) -> Any:
         """Process a single frame using ImageBuf-first operations."""
+        if self.reader is None:
+            raise RuntimeError("Reader must be initialized before processing frames.")
+        if self.color_converter is None:
+            raise RuntimeError("Color converter must be initialized before processing frames.")
         buf = self._prepare_frame_buf(
             frame_num,
             output_width,

--- a/src/renderkit/core/ffmpeg_utils.py
+++ b/src/renderkit/core/ffmpeg_utils.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ def _get_vendor_ffmpeg_candidates(root: Path) -> list[Path]:
     }
     platform_dir = platform_map.get(sys.platform)
     names = ["ffmpeg.exe"] if sys.platform == "win32" else ["ffmpeg"]
-    candidates = []
+    candidates: list[Path] = []
     if platform_dir:
         platform_root = vendor_root / platform_dir
         candidates.extend(platform_root / name for name in names)
@@ -40,7 +40,7 @@ def ensure_ffmpeg_env() -> None:
     if os.environ.get("IMAGEIO_FFMPEG_EXE"):
         return
 
-    candidates = []
+    candidates: list[Path] = []
     executable_dir = Path(sys.executable).resolve().parent
     compiled = getattr(builtins, "__compiled__", None)
     compiled_dir = Path(compiled.containing_dir) if compiled is not None else None
@@ -114,9 +114,9 @@ def get_ffprobe_exe() -> str:
     return name
 
 
-def popen_kwargs(prevent_sigint: bool = True) -> dict[str, object]:
+def popen_kwargs(prevent_sigint: bool = True) -> dict[str, Any]:
     """Return subprocess kwargs tuned for FFmpeg execution."""
-    kwargs: dict[str, object] = {}
+    kwargs: dict[str, Any] = {}
     if os.name == "nt":
         creationflags = subprocess.CREATE_NO_WINDOW
         if prevent_sigint:

--- a/src/renderkit/core/profiler.py
+++ b/src/renderkit/core/profiler.py
@@ -8,6 +8,7 @@ import logging
 import os
 import pstats
 import tempfile
+from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
@@ -69,7 +70,7 @@ def profile_context(
     enabled: bool,
     output_path: Optional[Path],
     label: str,
-) -> cProfile.Profile | None:
+) -> Iterator[cProfile.Profile | None]:
     """Context manager to run cProfile and persist results to disk."""
     if not enabled:
         yield None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,3 +158,65 @@ def test_convert_defaults_to_auto_progress_detection(monkeypatch, tmp_path) -> N
     assert len(calls) == 1
     _, show_progress = calls.pop()
     assert show_progress is None
+
+
+def test_contact_sheet_command_uses_still_writer(monkeypatch, tmp_path: Path) -> None:
+    """Verify the still contact sheet command wires CLI options into the writer."""
+    calls = []
+    output_path = tmp_path / "contact_sheet.jpg"
+
+    def fake_write_sequence_contact_sheet(
+        input_pattern,
+        output_path,
+        config,
+        layer,
+        start_frame,
+        end_frame,
+    ) -> None:
+        calls.append((input_pattern, output_path, config, layer, start_frame, end_frame))
+        output_path.touch()
+
+    monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
+    monkeypatch.setattr(cli_main, "setup_logging", lambda: None)
+    monkeypatch.setattr(
+        cli_main, "_write_sequence_contact_sheet", fake_write_sequence_contact_sheet
+    )
+
+    result = CliRunner().invoke(
+        cli_main.main,
+        [
+            "contact-sheet",
+            "render.%04d.exr",
+            str(output_path),
+            "--columns",
+            "3",
+            "--thumb-width",
+            "256",
+            "--padding",
+            "8",
+            "--no-labels",
+            "--font-size",
+            "12",
+            "--layer",
+            "diffuse",
+            "--start-frame",
+            "1001",
+            "--end-frame",
+            "1008",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(calls) == 1
+    input_pattern, called_output_path, config, layer, start_frame, end_frame = calls[0]
+    assert input_pattern == "render.%04d.exr"
+    assert called_output_path == output_path
+    assert config.columns == 3
+    assert config.thumbnail_width == 256
+    assert config.padding == 8
+    assert config.show_labels is False
+    assert config.font_size == 12
+    assert layer == "diffuse"
+    assert start_frame == 1001
+    assert end_frame == 1008
+    assert "Successfully created contact sheet" in result.output


### PR DESCRIPTION
## Summary
- scope mypy to the current CLI/core/API baseline and document the passing command
- fix type issues surfaced in the baseline instead of hiding them wholesale
- repair the stale still contact-sheet CLI path and add a regression test

Closes #81

## Verification
- uv run --extra dev mypy
- uv run ruff check src\\renderkit\\cli\\main.py src\\renderkit\\core\\converter.py src\\renderkit\\core\\profiler.py src\\renderkit\\core\\ffmpeg_utils.py src\\renderkit\\core\\config.py src\\renderkit\\api\\processor.py tests\\test_cli.py
- uv run python -m pytest tests\\test_cli.py tests\\test_contact_sheet.py -q
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional thumbnail width parameters in contact sheet generation.
  * Enhanced validation of conversion parameters to prevent runtime errors.

* **Chores**
  * Updated type-checking instructions in contributor documentation.
  * Strengthened type annotations across the codebase for improved code reliability.
  * Added test coverage for contact sheet command functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->