### PR TITLE
Tighten FFmpeg encoder probe handling

### DIFF
--- a/src/renderkit/processing/video_encoder.py
+++ b/src/renderkit/processing/video_encoder.py
@@ -4,6 +4,7 @@ import logging
 import os
 import subprocess
 import tempfile
+from dataclasses import dataclass
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
@@ -19,13 +20,42 @@ from renderkit.processing.scaler import ImageScaler
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class EncoderProbeResult:
+    """Structured result for FFmpeg encoder capability probing."""
+
+    encoders: frozenset[str]
+    error: Optional[str] = None
+
+    @property
+    def succeeded(self) -> bool:
+        return self.error is None
+
+    @property
+    def failed(self) -> bool:
+        return self.error is not None
+
+
 def _escape_ffreport_path(path: Path) -> str:
     if os.name == "nt":
         return path.as_posix().replace(":", r"\:")
     return str(path)
 
 
-def _probe_available_encoders() -> set[str]:
+def _probe_failure_result(error: str) -> EncoderProbeResult:
+    logger.warning("Unable to query FFmpeg encoders: %s", error)
+    return EncoderProbeResult(frozenset(), error=error)
+
+
+def _last_nonempty_line(text: str) -> Optional[str]:
+    for line in reversed(text.splitlines()):
+        line = line.strip()
+        if line:
+            return line
+    return None
+
+
+def _probe_available_encoders() -> EncoderProbeResult:
     try:
         cmd = [get_ffmpeg_exe(), "-hide_banner", "-encoders"]
         result = subprocess.run(
@@ -35,9 +65,15 @@ def _probe_available_encoders() -> set[str]:
             **popen_kwargs(prevent_sigint=True),
         )
         text = (result.stdout or "") + "\n" + (result.stderr or "")
-    except Exception as exc:
-        logger.warning("Unable to query FFmpeg encoders: %s", exc)
-        return set()
+    except (OSError, subprocess.SubprocessError) as exc:
+        return _probe_failure_result(str(exc))
+
+    if result.returncode != 0:
+        error = f"ffmpeg -encoders exited with code {result.returncode}"
+        output_tail = _last_nonempty_line(text)
+        if output_tail:
+            error = f"{error}: {output_tail}"
+        return _probe_failure_result(error)
 
     encoders: set[str] = set()
     for line in text.splitlines():
@@ -51,16 +87,20 @@ def _probe_available_encoders() -> set[str]:
             continue
         if parts[0].startswith("V"):
             encoders.add(parts[1])
-    return encoders
+    return EncoderProbeResult(frozenset(encoders))
 
 
 @lru_cache(maxsize=1)
-def _cached_available_encoders() -> frozenset[str]:
-    return frozenset(_probe_available_encoders())
+def _cached_encoder_probe_result() -> EncoderProbeResult:
+    return _probe_available_encoders()
+
+
+def get_encoder_probe_result() -> EncoderProbeResult:
+    return _cached_encoder_probe_result()
 
 
 def get_available_encoders() -> set[str]:
-    return set(_cached_available_encoders())
+    return set(get_encoder_probe_result().encoders)
 
 
 def select_available_encoder(requested: str, available: set[str]) -> tuple[str, Optional[str]]:
@@ -227,13 +267,17 @@ class VideoEncoder:
         self._ffreport_set = False
 
     def _read_ffmpeg_report_tail(self, max_lines: int = 80) -> Optional[str]:
+        """Best-effort FFmpeg report tail for error messages."""
         if self._ffmpeg_report_path is None:
             return None
         if not self._ffmpeg_report_path.exists():
             return None
         try:
             content = self._ffmpeg_report_path.read_text(errors="ignore")
-        except Exception:
+        except OSError as exc:
+            logger.debug(
+                "Unable to read FFmpeg report tail from %s: %s", self._ffmpeg_report_path, exc
+            )
             return None
         lines = [line for line in content.splitlines() if line.strip()]
         if not lines:
@@ -297,12 +341,22 @@ class VideoEncoder:
             "XVID": "mpeg4",
         }
         ffmpeg_codec = codec_map.get(self.codec, self.codec)
-        available_encoders = get_available_encoders()
+        encoder_probe = get_encoder_probe_result()
+        available_encoders = set(encoder_probe.encoders)
         ffmpeg_codec, fallback_warning = select_available_encoder(ffmpeg_codec, available_encoders)
         if fallback_warning:
             logger.warning(fallback_warning)
-        if available_encoders and ffmpeg_codec not in available_encoders:
-            available = ", ".join(sorted(available_encoders))
+        if encoder_probe.failed:
+            logger.warning(
+                "Skipping FFmpeg encoder availability validation because probing failed: %s. "
+                "Attempting '%s'.",
+                encoder_probe.error,
+                ffmpeg_codec,
+            )
+        elif ffmpeg_codec not in encoder_probe.encoders:
+            available = ", ".join(sorted(encoder_probe.encoders))
+            if not available:
+                available = "none"
             raise VideoEncodingError(
                 f"Requested FFmpeg encoder '{ffmpeg_codec}' is not available. "
                 f"Available encoders: {available}"

--- a/src/renderkit/ui/main_window_logic.py
+++ b/src/renderkit/ui/main_window_logic.py
@@ -27,7 +27,7 @@ from renderkit.processing.color_space import (
     get_ocio_role_display_options,
     resolve_ocio_role_label_for_colorspace,
 )
-from renderkit.processing.video_encoder import get_available_encoders, select_available_encoder
+from renderkit.processing.video_encoder import get_encoder_probe_result, select_available_encoder
 from renderkit.ui.conversion_worker import ConversionWorker
 from renderkit.ui.file_info_worker import FileInfoWorker
 from renderkit.ui.icons import icon_manager
@@ -1684,12 +1684,29 @@ class MainWindowLogicMixin:
             # Codec
             codec_index = self.codec_combo.currentIndex()
             codec_id = self._codec_map.get(codec_index, "libx264")
-            available_encoders = get_available_encoders()
+            encoder_probe = get_encoder_probe_result()
+            available_encoders = set(encoder_probe.encoders)
             resolved_codec, fallback_warning = select_available_encoder(
                 codec_id, available_encoders
             )
-            if available_encoders and resolved_codec not in available_encoders:
-                available = ", ".join(sorted(available_encoders))
+            if encoder_probe.failed:
+                QMessageBox.warning(
+                    self,
+                    "Encoder Probe Failed",
+                    (
+                        "Unable to validate FFmpeg encoder availability.\n\n"
+                        f"{encoder_probe.error}\n\n"
+                        f"RenderKit will attempt to use '{resolved_codec}'."
+                    ),
+                )
+                logger.warning(
+                    "Skipping FFmpeg encoder availability validation because probing failed: %s. "
+                    "Attempting '%s'.",
+                    encoder_probe.error,
+                    resolved_codec,
+                )
+            elif resolved_codec not in encoder_probe.encoders:
+                available = ", ".join(sorted(encoder_probe.encoders)) or "none"
                 QMessageBox.critical(
                     self,
                     "Encoder Unavailable",

--- a/tests/test_video_encoder.py
+++ b/tests/test_video_encoder.py
@@ -1,0 +1,138 @@
+"""Tests for FFmpeg video encoder probing and initialization."""
+
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from renderkit.exceptions import VideoEncodingError
+from renderkit.processing import video_encoder
+from renderkit.processing.video_encoder import EncoderProbeResult, VideoEncoder
+
+
+def test_probe_available_encoders_reports_subprocess_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """FFmpeg probe failures should be distinguishable from successful empty probes."""
+
+    def raise_os_error(*args, **kwargs):
+        raise OSError("ffmpeg missing")
+
+    monkeypatch.setattr(video_encoder, "get_ffmpeg_exe", lambda: "ffmpeg")
+    monkeypatch.setattr(video_encoder.subprocess, "run", raise_os_error)
+
+    with caplog.at_level(logging.WARNING, logger="renderkit.processing.video_encoder"):
+        result = video_encoder._probe_available_encoders()
+
+    assert result.failed
+    assert result.error == "ffmpeg missing"
+    assert result.encoders == frozenset()
+    assert "Unable to query FFmpeg encoders: ffmpeg missing" in caplog.text
+
+
+def test_probe_available_encoders_success_can_be_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful probe with no parsed encoders is not a probe failure."""
+
+    def run_empty_probe(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(video_encoder, "get_ffmpeg_exe", lambda: "ffmpeg")
+    monkeypatch.setattr(video_encoder.subprocess, "run", run_empty_probe)
+
+    result = video_encoder._probe_available_encoders()
+
+    assert result.succeeded
+    assert result.encoders == frozenset()
+    assert result.error is None
+
+
+def test_initialize_rejects_successful_empty_encoder_probe(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A successful empty encoder list should not be treated as an unknown capability state."""
+
+    def fail_if_writer_starts(*args, **kwargs):
+        raise AssertionError("writer should not start when encoder absence is confirmed")
+
+    monkeypatch.setattr(
+        video_encoder,
+        "get_encoder_probe_result",
+        lambda: EncoderProbeResult(frozenset()),
+    )
+    monkeypatch.setattr(video_encoder, "_RawFfmpegPipeWriter", fail_if_writer_starts)
+
+    encoder = VideoEncoder(output_path=tmp_path / "out.mp4", fps=24.0)
+
+    with pytest.raises(VideoEncodingError, match="Available encoders: none"):
+        encoder.initialize(1920, 1080)
+
+
+def test_initialize_attempts_requested_codec_when_probe_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Probe failures remain warning-only but are explicit in logs."""
+
+    captured: dict[str, str] = {}
+
+    class FakeWriter:
+        def __init__(
+            self,
+            output_path,
+            width,
+            height,
+            fps,
+            codec,
+            pix_fmt_in,
+            pix_fmt_out,
+            ffmpeg_params,
+            ffmpeg_log_level,
+            bitrate,
+        ) -> None:
+            captured["codec"] = codec
+
+    monkeypatch.setattr(
+        video_encoder,
+        "get_encoder_probe_result",
+        lambda: EncoderProbeResult(frozenset(), error="probe exploded"),
+    )
+    monkeypatch.setattr(video_encoder.VideoEncoder, "_configure_ffmpeg_report", lambda self: None)
+    monkeypatch.setattr(video_encoder, "_RawFfmpegPipeWriter", FakeWriter)
+
+    encoder = VideoEncoder(output_path=tmp_path / "out.mp4", fps=24.0, codec="libx264")
+
+    with caplog.at_level(logging.WARNING, logger="renderkit.processing.video_encoder"):
+        encoder.initialize(1920, 1080)
+
+    assert captured == {"codec": "libx264"}
+    assert encoder.is_initialized()
+    assert "Skipping FFmpeg encoder availability validation because probing failed" in caplog.text
+    assert "probe exploded" in caplog.text
+
+
+def test_read_ffmpeg_report_tail_ignores_os_read_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Report tails are best-effort diagnostics and should not mask encoding errors."""
+
+    report_path = tmp_path / "ffmpeg.log"
+    report_path.write_text("ffmpeg output", encoding="utf-8")
+    encoder = VideoEncoder(output_path=tmp_path / "out.mp4", fps=24.0)
+    encoder._ffmpeg_report_path = report_path
+
+    def raise_os_error(self, *args, **kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_text", raise_os_error)
+
+    with caplog.at_level(logging.DEBUG, logger="renderkit.processing.video_encoder"):
+        assert encoder._read_ffmpeg_report_tail() is None
+
+    assert "Unable to read FFmpeg report tail" in caplog.text
+    assert "permission denied" in caplog.text


### PR DESCRIPTION
## Summary
- add a structured FFmpeg encoder probe result so probe failures are distinguishable from successful empty encoder lists
- make encoder initialization warning-only on probe failure, but fail explicitly when a successful probe confirms the requested encoder is unavailable
- update UI codec validation to surface probe failure separately from unavailable encoders
- narrow FFmpeg report-tail read handling to documented best-effort OSError handling

Closes #84

## Tests
- uv run --extra dev ruff check src\\renderkit\\processing\\video_encoder.py src\\renderkit\\ui\\main_window_logic.py tests\\test_video_encoder.py
- uv run --extra dev pytest tests\\test_video_encoder.py
- uv run --extra dev pytest tests\\test_converter.py tests\\test_color_space.py
- uv run --extra dev pytest