### PR TITLE
Clarify contact sheet label help text

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -398,7 +398,7 @@ explicit `replace-sequence-with-mp4` calls or stage renamed MP4s in `--mp4-dir`.
 | `--columns` | Number of grid columns. | `4` |
 | `--thumb-width` | Width of each thumbnail. | Source resolution |
 | `--padding` | Padding between thumbnails. | `4` |
-| `--no-labels` | Disable filename labels below thumbnails. | `False` |
+| `--no-labels` | Disable layer labels below thumbnails. | `False` |
 | `--font-size` | Label font size. | `16` |
 | `--layer` | EXR layer/AOV to extract. | None |
 | `--start-frame` | Start frame number. | First frame |

--- a/src/renderkit/cli/main.py
+++ b/src/renderkit/cli/main.py
@@ -301,7 +301,7 @@ main.add_command(batch_convert)
 )
 @click.option("--padding", type=int, default=4, help="Padding between thumbnails (default: 4)")
 @click.option(
-    "--no-labels", is_flag=True, default=False, help="Disable filename labels below thumbnails"
+    "--no-labels", is_flag=True, default=False, help="Disable layer labels below thumbnails"
 )
 @click.option("--font-size", type=int, default=16, help="Font size for labels (default: 16)")
 @click.option(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,18 @@ def test_help_lists_ui_command(monkeypatch) -> None:
     assert "gui" not in result.output
 
 
+def test_contact_sheet_help_describes_layer_labels(monkeypatch) -> None:
+    """Contact sheet labels identify EXR layers, not source filenames."""
+    monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
+    monkeypatch.setattr(cli_main, "setup_logging", lambda: None)
+
+    result = CliRunner().invoke(cli_main.main, ["contact-sheet", "--help"])
+
+    assert result.exit_code == 0
+    assert "Disable layer labels below thumbnails" in result.output
+    assert "filename labels" not in result.output
+
+
 def test_ui_command_launches_gui(monkeypatch) -> None:
     """Verify the ui command dispatches to the Qt launcher."""
     launched = False


### PR DESCRIPTION
## Summary
- update contact-sheet CLI help from filename labels to layer labels
- update the usage docs table to match the rendered label semantics
- add a CLI help regression test for the label wording

Follow-up to review feedback after #88.

## Tests
- uv run --extra dev pytest tests\\test_cli.py
- uv run --extra dev ruff check src\\renderkit\\cli\\main.py tests\\test_cli.py