### PR TITLE
Clean up contact-sheet CLI errors

### DIFF
--- a/src/renderkit/cli/main.py
+++ b/src/renderkit/cli/main.py
@@ -466,7 +466,7 @@ def contact_sheet(
         logger.info(f"Successfully created contact sheet: {output_path}")
         click.echo(f"Successfully created contact sheet: {output_path}")
     except (RenderKitError, OSError, RuntimeError, ValueError) as e:
-        logger.exception("Contact sheet generation failed")
+        logger.debug("Contact sheet generation failed", exc_info=True)
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -232,3 +232,23 @@ def test_contact_sheet_command_uses_still_writer(monkeypatch, tmp_path: Path) ->
     assert start_frame == 1001
     assert end_frame == 1008
     assert "Successfully created contact sheet" in result.output
+
+
+def test_contact_sheet_invalid_input_returns_clean_cli_error(monkeypatch, tmp_path: Path) -> None:
+    """Invalid contact sheet inputs should not expose implementation tracebacks."""
+    monkeypatch.setattr(cli_main, "ensure_ffmpeg_env", lambda: None)
+
+    result = CliRunner().invoke(
+        cli_main.main,
+        [
+            "contact-sheet",
+            str(tmp_path / "missing.%04d.exr"),
+            str(tmp_path / "contact_sheet.jpg"),
+            "--overwrite",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Error: Could not detect frame sequence." in result.output
+    assert "Traceback" not in result.output
+    assert "AttributeError" not in result.output


### PR DESCRIPTION
## Summary
- keep handled `renderkit contact-sheet` failures out of the default console traceback path
- add CLI regression coverage for missing input sequences so the command returns a clean user-facing error

## Root cause
The standalone contact-sheet command now routes through the real still-writer path, but handled failures were still logged with `logger.exception`, which made invalid input look like an unexpected crash in normal CLI output.

## Validation
- `uv --native-tls run --extra dev pytest tests/test_cli.py tests/test_contact_sheet.py`
- `uv --native-tls run ruff check`
- `uv --native-tls run ruff format --check src/renderkit/cli/main.py tests/test_cli.py`
- `uv --native-tls run renderkit contact-sheet "C:\tmp\missing.%04d.exr" "C:\tmp\out.jpg" --overwrite`

Closes #80
