### PR TITLE
Propagate FFmpeg finalization failures

### DIFF
--- a/src/renderkit/core/converter.py
+++ b/src/renderkit/core/converter.py
@@ -444,7 +444,13 @@ class SequenceConverter:
             if pbar is not None:
                 pbar.close()
             if self.encoder:
-                self.encoder.close()
+                if sys.exception() is None:
+                    self.encoder.close()
+                else:
+                    try:
+                        self.encoder.close()
+                    except VideoEncodingError:
+                        logger.exception("Video encoder finalization failed during cleanup.")
 
     def _prepare_frame_buf(
         self,

--- a/src/renderkit/processing/video_encoder.py
+++ b/src/renderkit/processing/video_encoder.py
@@ -193,6 +193,11 @@ class _RawFfmpegPipeWriter:
             except Exception as exc:
                 logger.warning("Error closing FFmpeg stdin: %s", exc)
             self._process.wait()
+        if self._process.returncode:
+            raise RuntimeError(
+                f"FFmpeg exited with code {self._process.returncode} while finalizing video."
+                f"\n\nFFMPEG COMMAND:\n{self._cmd_str}"
+            )
 
 
 class VideoEncoder:
@@ -497,15 +502,23 @@ class VideoEncoder:
 
     def close(self) -> None:
         """Close the video writer."""
-        if self._writer is not None:
-            try:
-                self._writer.close()
-                logger.info("Video encoding completed.")
-            except Exception as e:
-                logger.error(f"Error closing video writer: {e}")
-            finally:
-                self._writer = None
-        self._restore_ffmpeg_report_env()
+        try:
+            if self._writer is not None:
+                try:
+                    self._writer.close()
+                    logger.info("Video encoding completed.")
+                except Exception as e:
+                    logger.error(f"Error closing video writer: {e}")
+                    report_tail = self._read_ffmpeg_report_tail()
+                    if report_tail:
+                        raise VideoEncodingError(
+                            f"Failed to finalize video encoding: {e}\n\n{report_tail}"
+                        ) from e
+                    raise VideoEncodingError(f"Failed to finalize video encoding: {e}") from e
+                finally:
+                    self._writer = None
+        finally:
+            self._restore_ffmpeg_report_env()
 
     def is_initialized(self) -> bool:
         """Check if encoder is initialized."""

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -274,6 +274,95 @@ class TestSequenceConverterFailures:
                 contact_sheet_generator=FailingContactSheetGenerator(),
             )
 
+    def test_process_frames_raises_encoder_finalization_failure(self) -> None:
+        """Close-time encoder failures should fail an otherwise successful conversion."""
+
+        class FailingCloseEncoder:
+            def write_frame(self, _buf) -> None:
+                # This test isolates encoder finalization; frame writing is stubbed out.
+                pass
+
+            def close(self) -> None:
+                raise VideoEncodingError("final mp4 flush failed")
+
+        converter = self._converter()
+        converter.encoder = FailingCloseEncoder()
+        converter._process_single_frame_buf = lambda *args, **kwargs: _FakeBuf()
+
+        with pytest.raises(VideoEncodingError, match="final mp4 flush failed"):
+            converter._process_frames(
+                frame_numbers=[1],
+                output_width=100,
+                output_height=100,
+                width=100,
+                height=100,
+                input_space=None,
+                file_info=FileInfo(width=100, height=100, channels=4, layers=[]),
+                progress_callback=None,
+                show_progress=False,
+            )
+
+    def test_process_frames_preserves_frame_failure_over_cleanup_failure(self) -> None:
+        """Cleanup failures should not hide the frame-processing error already in flight."""
+
+        class FailingCloseEncoder:
+            def close(self) -> None:
+                raise VideoEncodingError("final mp4 flush failed")
+
+        converter = self._converter()
+        converter.encoder = FailingCloseEncoder()
+
+        def raise_frame_failure(*args, **kwargs):
+            raise VideoEncodingError("frame preparation failed")
+
+        converter._process_single_frame_buf = raise_frame_failure
+
+        with pytest.raises(VideoEncodingError, match="frame preparation failed"):
+            converter._process_frames(
+                frame_numbers=[1],
+                output_width=100,
+                output_height=100,
+                width=100,
+                height=100,
+                input_space=None,
+                file_info=FileInfo(width=100, height=100, channels=4, layers=[]),
+                progress_callback=None,
+                show_progress=False,
+            )
+
+    def test_process_frames_finalizes_after_successful_frame_writes(self) -> None:
+        """Successful frame writes should still reach encoder finalization."""
+
+        class ClosingEncoder:
+            def __init__(self) -> None:
+                self.closed = False
+
+            def write_frame(self, _buf) -> None:
+                # This test only asserts finalization after successful frame processing.
+                pass
+
+            def close(self) -> None:
+                self.closed = True
+
+        encoder = ClosingEncoder()
+        converter = self._converter()
+        converter.encoder = encoder
+        converter._process_single_frame_buf = lambda *args, **kwargs: _FakeBuf()
+
+        converter._process_frames(
+            frame_numbers=[1],
+            output_width=100,
+            output_height=100,
+            width=100,
+            height=100,
+            input_space=None,
+            file_info=FileInfo(width=100, height=100, channels=4, layers=[]),
+            progress_callback=None,
+            show_progress=False,
+        )
+
+        assert encoder.closed
+
 
 class TestSequenceConverterProgress:
     """Tests for CLI progress-bar behavior."""

--- a/tests/test_video_encoder.py
+++ b/tests/test_video_encoder.py
@@ -8,7 +8,11 @@ import pytest
 
 from renderkit.exceptions import VideoEncodingError
 from renderkit.processing import video_encoder
-from renderkit.processing.video_encoder import EncoderProbeResult, VideoEncoder
+from renderkit.processing.video_encoder import (
+    EncoderProbeResult,
+    VideoEncoder,
+    _RawFfmpegPipeWriter,
+)
 
 
 def test_probe_available_encoders_reports_subprocess_failure(
@@ -136,3 +140,63 @@ def test_read_ffmpeg_report_tail_ignores_os_read_failure(
 
     assert "Unable to read FFmpeg report tail" in caplog.text
     assert "permission denied" in caplog.text
+
+
+def test_raw_ffmpeg_pipe_writer_close_raises_on_nonzero_returncode() -> None:
+    """FFmpeg finalization failures should be reported after the process exits."""
+
+    class FakeStdin:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class FakeProcess:
+        def __init__(self) -> None:
+            self.stdin = FakeStdin()
+            self.returncode = None
+
+        def poll(self):
+            return None
+
+        def wait(self) -> None:
+            self.returncode = 42
+
+    process = FakeProcess()
+    writer = _RawFfmpegPipeWriter.__new__(_RawFfmpegPipeWriter)
+    writer._process = process
+    writer._cmd_str = "ffmpeg -i pipe:0 out.mp4"
+
+    with pytest.raises(RuntimeError, match="FFmpeg exited with code 42"):
+        writer.close()
+
+    assert process.stdin.closed
+
+
+def test_video_encoder_close_raises_finalization_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Writer close exceptions should propagate as VideoEncodingError."""
+
+    class FailingWriter:
+        def close(self) -> None:
+            raise RuntimeError("simulated ffmpeg finalization failure")
+
+    restored = False
+
+    def restore_env(self) -> None:
+        nonlocal restored
+        restored = True
+
+    monkeypatch.setattr(VideoEncoder, "_restore_ffmpeg_report_env", restore_env)
+
+    encoder = VideoEncoder(output_path=tmp_path / "out.mp4", fps=24.0)
+    encoder._writer = FailingWriter()
+
+    with pytest.raises(VideoEncodingError, match="Failed to finalize video encoding"):
+        encoder.close()
+
+    assert encoder._writer is None
+    assert restored


### PR DESCRIPTION
## Summary
- propagate writer close failures from `VideoEncoder.close()` as `VideoEncodingError`
- check raw FFmpeg process return codes after finalization waits
- keep earlier conversion errors primary when encoder cleanup also fails
- add regression tests for close-time writer failures, nonzero FFmpeg exits, and converter finalization behavior

Closes #93

## Validation
- `uv --native-tls run ruff check src\renderkit\processing\video_encoder.py src\renderkit\core\converter.py tests\test_video_encoder.py tests\test_converter.py`
- `uv --native-tls run --extra dev pytest tests/test_video_encoder.py tests/test_converter.py`
- `uv --native-tls run --extra dev pytest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video encoder error handling to explicitly report finalization failures, preventing silent suppression of encoding errors.
  * Enhanced error precedence during cleanup to preserve original errors when encoder finalization also fails.

* **Tests**
  * Extended test coverage for video encoder finalization and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->