### PR TITLE
Always use bundled OCIO config

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -420,8 +420,7 @@ calls or stage renamed MP4s in `--mp4-dir`.
 
 - FPS auto-detection logs a warning when metadata probing is unavailable or image metadata cannot
   be read, then falls back to the configured/default FPS behavior.
-- OCIO conversions use RenderKit's bundled OCIO config. The `OCIO` environment variable is not
-  read or modified by RenderKit.
+- OCIO conversions use RenderKit's bundled OCIO config.
 - OCIO conversion failures include diagnostics in the RenderKit log, including role and color-space
   resolution details, available color-space samples, and bundled LUT/config checks where possible.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -408,7 +408,6 @@ calls or stage renamed MP4s in `--mp4-dir`.
 
 ## Environment Variables
 
-- `OCIO`: Path to your system OCIO config when using custom/ACES input spaces.
 - `IMAGEIO_FFMPEG_EXE`: Path to a custom ffmpeg binary; overrides the bundled or PATH ffmpeg.
 - `RENDERKIT_FFMPEG_LOG`: FFmpeg report logging. Use `0` to disable, `1` for a temp log, or a full file path.
 - `RENDERKIT_PROFILE`: Enable cProfile output for UI/CLI when set to `1`, `true`, or `yes`.
@@ -421,6 +420,8 @@ calls or stage renamed MP4s in `--mp4-dir`.
 
 - FPS auto-detection logs a warning when metadata probing is unavailable or image metadata cannot
   be read, then falls back to the configured/default FPS behavior.
+- OCIO conversions use RenderKit's bundled OCIO config. The `OCIO` environment variable is not
+  read or modified by RenderKit.
 - OCIO conversion failures include diagnostics in the RenderKit log, including role and color-space
   resolution details, available color-space samples, and bundled LUT/config checks where possible.
 

--- a/src/renderkit/processing/color_space.py
+++ b/src/renderkit/processing/color_space.py
@@ -148,7 +148,6 @@ def _oiio_colorconvert_buf(
     src_buf,
     from_spaces: list[str],
     to_spaces: list[str],
-    color_config_path: Optional[str] = None,
 ):
     src_buf = _ensure_float_buf(oiio, src_buf)
     spec = src_buf.spec()
@@ -156,7 +155,7 @@ def _oiio_colorconvert_buf(
     if channels not in (3, 4):
         raise ColorSpaceError("Color conversion expects 3 or 4 channel images.")
 
-    resolved_color_config_path = color_config_path or str(get_bundled_ocio_config_path())
+    bundled_color_config_path = str(get_bundled_ocio_config_path())
     space_map = _get_oiio_color_space_map(oiio)
     from_candidates = _resolve_oiio_spaces(from_spaces, space_map)
     to_candidates = _resolve_oiio_spaces(to_spaces, space_map)
@@ -175,7 +174,7 @@ def _oiio_colorconvert_buf(
                 True,
                 "",
                 "",
-                resolved_color_config_path,
+                bundled_color_config_path,
             ):
                 return dst_buf
             err = dst_buf.geterror()
@@ -538,7 +537,6 @@ class OCIOColorSpaceStrategy:
                 buf,
                 [resolved_input_space],
                 [resolved_output_space],
-                color_config_path=str(self.config_path),
             )
         except Exception as e:
             self._log_ocio_failure_diagnostics(

--- a/src/renderkit/processing/color_space.py
+++ b/src/renderkit/processing/color_space.py
@@ -1,8 +1,8 @@
 """Color space conversion using Strategy pattern."""
 
 import logging
-import os
 import re
+import sys
 from enum import Enum
 from pathlib import Path
 from typing import Any, Optional, Protocol
@@ -24,6 +24,27 @@ _OIIO_REC709_CANDIDATES = [
     "Output - Rec709",
 ]
 _OIIO_COLOR_SPACE_CACHE: Optional[dict[str, str]] = None
+_BUNDLED_OCIO_CONFIG_CACHE: Optional[Path] = None
+
+
+def get_bundled_ocio_config_path() -> Path:
+    """Return RenderKit's bundled OCIO config path."""
+    global _BUNDLED_OCIO_CONFIG_CACHE
+    if _BUNDLED_OCIO_CONFIG_CACHE is not None:
+        return _BUNDLED_OCIO_CONFIG_CACHE
+
+    candidates: list[Path] = []
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+        candidates.append(Path(sys._MEIPASS) / "renderkit" / "data" / "ocio" / "config.ocio")
+
+    candidates.append(Path(__file__).resolve().parent.parent / "data" / "ocio" / "config.ocio")
+
+    for candidate in candidates:
+        if candidate.exists():
+            _BUNDLED_OCIO_CONFIG_CACHE = candidate.resolve()
+            return _BUNDLED_OCIO_CONFIG_CACHE
+
+    raise ColorSpaceError("Bundled OCIO config not found.")
 
 
 def _summarize_list(values: list[str], max_items: int = 20) -> str:
@@ -44,7 +65,7 @@ def _get_oiio_color_space_map(oiio) -> dict[str, str]:
     if _OIIO_COLOR_SPACE_CACHE is not None:
         return _OIIO_COLOR_SPACE_CACHE
     try:
-        config = oiio.ColorConfig()
+        config = oiio.ColorConfig(str(get_bundled_ocio_config_path()))
         names = config.getColorSpaceNames()
         if not names:
             raise ColorSpaceError("OCIO config does not define any color spaces.")
@@ -122,13 +143,20 @@ def _oiio_tone_map_reinhard(oiio, buf):
     return _oiio_clamp_buf(oiio, tone, 0.0, 1.0)
 
 
-def _oiio_colorconvert_buf(oiio, src_buf, from_spaces: list[str], to_spaces: list[str]):
+def _oiio_colorconvert_buf(
+    oiio,
+    src_buf,
+    from_spaces: list[str],
+    to_spaces: list[str],
+    color_config_path: Optional[str] = None,
+):
     src_buf = _ensure_float_buf(oiio, src_buf)
     spec = src_buf.spec()
     channels = spec.nchannels
     if channels not in (3, 4):
         raise ColorSpaceError("Color conversion expects 3 or 4 channel images.")
 
+    resolved_color_config_path = color_config_path or str(get_bundled_ocio_config_path())
     space_map = _get_oiio_color_space_map(oiio)
     from_candidates = _resolve_oiio_spaces(from_spaces, space_map)
     to_candidates = _resolve_oiio_spaces(to_spaces, space_map)
@@ -139,7 +167,16 @@ def _oiio_colorconvert_buf(oiio, src_buf, from_spaces: list[str], to_spaces: lis
             dst_buf = oiio.ImageBuf(
                 oiio.ImageSpec(spec.width, spec.height, spec.nchannels, oiio.FLOAT)
             )
-            if oiio.ImageBufAlgo.colorconvert(dst_buf, src_buf, from_space, to_space):
+            if oiio.ImageBufAlgo.colorconvert(
+                dst_buf,
+                src_buf,
+                from_space,
+                to_space,
+                True,
+                "",
+                "",
+                resolved_color_config_path,
+            ):
                 return dst_buf
             err = dst_buf.geterror()
             if err:
@@ -185,7 +222,7 @@ def get_ocio_role_space_map() -> dict[str, str]:
         return {}
 
     try:
-        config = OCIO.GetCurrentConfig()
+        config = OCIO.Config.CreateFromFile(str(get_bundled_ocio_config_path()))
         roles = list(config.getRoleNames())
     except Exception:
         return {}
@@ -221,7 +258,7 @@ def get_ocio_colorspace_label(name: str) -> Optional[str]:
         return None
 
     try:
-        config = OCIO.GetCurrentConfig()
+        config = OCIO.Config.CreateFromFile(str(get_bundled_ocio_config_path()))
         spaces = set(config.getColorSpaceNames())
     except Exception:
         return None
@@ -292,9 +329,10 @@ class OCIOColorSpaceStrategy:
             raise ColorSpaceError("PyOpenColorIO not available.") from e
 
         try:
-            self.config = OCIO.GetCurrentConfig()
+            self.config_path = get_bundled_ocio_config_path()
+            self.config = OCIO.Config.CreateFromFile(str(self.config_path))
         except Exception as e:
-            raise ColorSpaceError(f"Failed to get OCIO config: {e}") from e
+            raise ColorSpaceError(f"Failed to load bundled OCIO config: {e}") from e
 
     def _resolve_input_space(self, input_space: str) -> str:
         if not input_space or not self.config:
@@ -372,14 +410,6 @@ class OCIOColorSpaceStrategy:
         resolved_output_space: Optional[str],
         error: Exception,
     ) -> None:
-        ocio_env = os.environ.get("OCIO")
-        ocio_env_exists = False
-        if ocio_env:
-            try:
-                ocio_env_exists = Path(ocio_env).exists()
-            except OSError:
-                ocio_env_exists = False
-
         config_version = "unknown"
         search_path = "unknown"
         default_display = "unknown"
@@ -391,6 +421,7 @@ class OCIOColorSpaceStrategy:
         config_file_crlf = "unknown"
         lut_sources_count = 0
         lut_diagnostics: list[str] = []
+        config_path: Optional[Path] = getattr(self, "config_path", None)
 
         try:
             major = self.config.getMajorVersion()
@@ -431,9 +462,9 @@ class OCIOColorSpaceStrategy:
             except Exception as proc_error:
                 processor_status = f"failed: {proc_error}"
 
-        if ocio_env_exists and ocio_env:
+        if config_path and config_path.exists():
             try:
-                ocio_path = Path(ocio_env)
+                ocio_path = config_path
                 config_bytes = ocio_path.read_bytes()
                 config_file_crlf = str(_count_crlf_pairs(config_bytes))
                 config_text = config_bytes.decode("utf-8", errors="replace")
@@ -455,7 +486,7 @@ class OCIOColorSpaceStrategy:
 
         logger.error(
             "OCIO diagnostics: error=%s requested_input=%s resolved_input=%s resolved_output=%s "
-            "ocio_env=%s ocio_env_exists=%s config_version=%s search_path=%s "
+            "config_path=%s config_exists=%s config_version=%s search_path=%s "
             "default_display=%s default_view=%s display_view_space=%s processor_status=%s "
             "colorspaces_count=%s colorspaces_sample=%s roles=%s "
             "config_crlf=%s lut_sources_count=%s lut_diagnostics=%s",
@@ -463,8 +494,8 @@ class OCIOColorSpaceStrategy:
             requested_input_space,
             resolved_input_space,
             resolved_output_space,
-            ocio_env,
-            ocio_env_exists,
+            config_path,
+            bool(config_path and config_path.exists()),
             config_version,
             search_path,
             default_display,
@@ -503,7 +534,11 @@ class OCIOColorSpaceStrategy:
                 resolved_output_space,
             )
             return _oiio_colorconvert_buf(
-                oiio, buf, [resolved_input_space], [resolved_output_space]
+                oiio,
+                buf,
+                [resolved_input_space],
+                [resolved_output_space],
+                color_config_path=str(self.config_path),
             )
         except Exception as e:
             self._log_ocio_failure_diagnostics(

--- a/src/renderkit/ui/main_window.py
+++ b/src/renderkit/ui/main_window.py
@@ -82,7 +82,7 @@ class ModernMainWindow(MainWindowUiMixin, MainWindowLogicMixin, QMainWindow):
         self.timeline_controller: Optional[TimelineController] = None
 
         self._setup_logging()
-        self._ensure_ocio_env()
+        self._ensure_bundled_ocio_config()
 
         # UI element references for responsive layout
         self.main_splitter: Optional[QSplitter] = None

--- a/src/renderkit/ui/main_window_logic.py
+++ b/src/renderkit/ui/main_window_logic.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import logging
 import math
-import os
-import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -23,6 +21,7 @@ from renderkit.io.file_utils import FileUtils
 from renderkit.logging_utils import setup_logging
 from renderkit.processing.color_space import (
     ColorSpacePreset,
+    get_bundled_ocio_config_path,
     get_ocio_colorspace_label,
     get_ocio_role_display_options,
     resolve_ocio_role_label_for_colorspace,
@@ -211,32 +210,15 @@ SETTINGS_SCHEMA: tuple[_SettingSpec, ...] = (
 class MainWindowLogicMixin:
     """Signal handlers, validation, and worker orchestration."""
 
-    def _ensure_ocio_env(self) -> None:
-        """Ensure OCIO environment variable is set, using bundled config if needed."""
-        bundled_config = None
-        if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
-            candidate = Path(sys._MEIPASS) / "renderkit" / "data" / "ocio" / "config.ocio"
-            if candidate.exists():
-                bundled_config = candidate
-        else:
-            # Dev mode: assuming this file is in src/renderkit/ui/main_window.py
-            # Config is in src/renderkit/data/ocio/config.ocio
-            # ../../data/ocio/config.ocio
-            current_dir = Path(__file__).parent
-            candidate = current_dir.parent / "data" / "ocio" / "config.ocio"
-            if candidate.exists():
-                bundled_config = candidate
-
-        if bundled_config:
-            logger.info(f"Setting OCIO environment variable to bundled config: {bundled_config}")
-            os.environ["OCIO"] = str(bundled_config.resolve())
+    def _ensure_bundled_ocio_config(self) -> None:
+        """Ensure RenderKit's bundled OCIO config is available."""
+        try:
+            bundled_config = get_bundled_ocio_config_path()
+        except RenderKitError as exc:
+            logger.warning("Could not find bundled ocio/config.ocio: %s", exc)
             return
 
-        if os.environ.get("OCIO"):
-            logger.info(f"Using existing OCIO environment variable: {os.environ['OCIO']}")
-            return
-
-        logger.warning("Could not find bundled ocio/config.ocio and OCIO env var is not set.")
+        logger.info("Using bundled OCIO config: %s", bundled_config)
 
     def keyPressEvent(self, event) -> None:
         """Handle global key presses for the main window."""

--- a/tests/test_color_space.py
+++ b/tests/test_color_space.py
@@ -12,6 +12,7 @@ from renderkit.processing.color_space import (
     ColorSpacePreset,
     NoConversionStrategy,
     OCIOColorSpaceStrategy,
+    get_bundled_ocio_config_path,
 )
 
 try:
@@ -193,7 +194,7 @@ def _has_oiio_colorspace_candidates(candidates: list[str]) -> bool:
         return False
 
     try:
-        config = oiio.ColorConfig()
+        config = oiio.ColorConfig(str(get_bundled_ocio_config_path()))
         names = config.getColorSpaceNames()
     except Exception:
         return False

--- a/tests/test_color_space.py
+++ b/tests/test_color_space.py
@@ -1,6 +1,7 @@
 """Tests for color space conversion."""
 
 import logging
+import os
 from unittest.mock import Mock
 
 import numpy as np
@@ -57,6 +58,20 @@ class TestColorSpaceConverter:
         assert srgb_image.dtype == np.float32
         assert np.all(srgb_image >= 0.0)
         assert np.all(srgb_image <= 1.0)
+
+    def test_linear_to_srgb_uses_bundled_config_when_ocio_env_is_invalid(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test OIIO color conversion ignores an invalid OCIO environment variable."""
+        monkeypatch.setenv("OCIO", "C:/does/not/exist/config.ocio")
+        converter = ColorSpaceConverter(ColorSpacePreset.LINEAR_TO_SRGB)
+
+        linear_image = np.array([[[0.18, 0.18, 0.18]]], dtype=np.float32)
+        result_buf = converter.convert_buf(_make_buf(linear_image))
+        result = _buf_to_array(result_buf)
+
+        assert result.shape == linear_image.shape
+        assert os.environ["OCIO"] == "C:/does/not/exist/config.ocio"
 
     def test_no_conversion(self) -> None:
         """Test no conversion strategy."""

--- a/tests/test_ocio_env_setup.py
+++ b/tests/test_ocio_env_setup.py
@@ -8,22 +8,25 @@ from unittest.mock import patch
 src_path = Path(__file__).parent.parent / "src"
 sys.path.append(str(src_path))
 
+import renderkit.processing.color_space as color_space  # noqa: E402
+from renderkit.processing.color_space import (  # noqa: E402
+    OCIOColorSpaceStrategy,
+    get_bundled_ocio_config_path,
+)
 from renderkit.ui.main_window import ModernMainWindow  # noqa: E402
 
 
-class TestOCIOEnvSetup(unittest.TestCase):
+class TestOCIOConfigSetup(unittest.TestCase):
     def setUp(self):
-        # Save original OCIO env
         self.original_ocio = os.environ.get("OCIO")
-        if "OCIO" in os.environ:
-            del os.environ["OCIO"]
+        color_space._BUNDLED_OCIO_CONFIG_CACHE = None
 
     def tearDown(self):
-        # Restore
         if self.original_ocio:
             os.environ["OCIO"] = self.original_ocio
-        elif "OCIO" in os.environ:
-            del os.environ["OCIO"]
+        else:
+            os.environ.pop("OCIO", None)
+        color_space._BUNDLED_OCIO_CONFIG_CACHE = None
 
     @patch("renderkit.ui.main_window.ModernMainWindow._setup_ui")
     @patch("renderkit.ui.main_window.ModernMainWindow._apply_theme")
@@ -31,21 +34,14 @@ class TestOCIOEnvSetup(unittest.TestCase):
     @patch("renderkit.ui.main_window.ModernMainWindow._load_settings")
     @patch("renderkit.ui.main_window.ModernMainWindow._setup_connections")
     @patch("renderkit.ui.main_window.QMainWindow.__init__")
-    def test_ensure_ocio_env_dev_mode(self, mock_init, *args):
-        # Ensure we have a dummy bundled config structure mocked or real
-        # If we run in dev mode, logic looks at ../data/ocio/config.ocio relative to main_window logic
-        # That path likely exists in this repo.
-
-        # Scenario: OCIO is NOT set. Should pick up bundled.
-        if "OCIO" in os.environ:
-            del os.environ["OCIO"]
+    def test_ensure_bundled_ocio_config_does_not_create_env_var(self, mock_init, *args):
+        os.environ.pop("OCIO", None)
 
         window = ModernMainWindow.__new__(ModernMainWindow)
-        window._ensure_ocio_env()
+        window._ensure_bundled_ocio_config()
 
-        self.assertIn("OCIO", os.environ)
-        self.assertTrue(os.environ["OCIO"].endswith("config.ocio"))
-        print(f"Verified OCIO detected at: {os.environ['OCIO']}")
+        self.assertNotIn("OCIO", os.environ)
+        self.assertTrue(get_bundled_ocio_config_path().name == "config.ocio")
 
     @patch("renderkit.ui.main_window.ModernMainWindow._setup_ui")
     @patch("renderkit.ui.main_window.ModernMainWindow._apply_theme")
@@ -53,21 +49,15 @@ class TestOCIOEnvSetup(unittest.TestCase):
     @patch("renderkit.ui.main_window.ModernMainWindow._load_settings")
     @patch("renderkit.ui.main_window.ModernMainWindow._setup_connections")
     @patch("renderkit.ui.main_window.QMainWindow.__init__")
-    def test_ocio_env_overwrites_system_if_bundled_exists(self, mock_init, *args):
-        # Scenario: OCIO IS set to something else.
-        # Logic should overwrite it with bundled if bundled exists.
-
-        # We need to ensure bundled path 'exists' for the logic to trigger the overwrite.
-        # In this test environment (dev mode), the real file exists.
-
-        os.environ["OCIO"] = "C:/some/system/path/config.ocio"
+    def test_ensure_bundled_ocio_config_does_not_overwrite_env_var(self, mock_init, *args):
+        existing_ocio = "C:/some/system/path/config.ocio"
+        os.environ["OCIO"] = existing_ocio
 
         window = ModernMainWindow.__new__(ModernMainWindow)
-        window._ensure_ocio_env()
+        window._ensure_bundled_ocio_config()
 
-        self.assertNotEqual(os.environ["OCIO"], "C:/some/system/path/config.ocio")
-        self.assertTrue(os.environ["OCIO"].endswith("config.ocio"))
-        print(f"Verified system env was overridden by: {os.environ['OCIO']}")
+        self.assertEqual(os.environ["OCIO"], existing_ocio)
+        self.assertTrue(get_bundled_ocio_config_path().name == "config.ocio")
 
     @patch("sys.frozen", True, create=True)
     @patch("sys._MEIPASS", str(Path(__file__).parent.parent / "src"), create=True)
@@ -77,13 +67,23 @@ class TestOCIOEnvSetup(unittest.TestCase):
     @patch("renderkit.ui.main_window.ModernMainWindow._load_settings")
     @patch("renderkit.ui.main_window.ModernMainWindow._setup_connections")
     @patch("renderkit.ui.main_window.QMainWindow.__init__")
-    def test_ensure_ocio_env_frozen_mode(self, mock_init, *args):
-        window = ModernMainWindow.__new__(ModernMainWindow)
-        window._ensure_ocio_env()
+    def test_ensure_bundled_ocio_config_frozen_mode(self, mock_init, *args):
+        os.environ.pop("OCIO", None)
 
-        self.assertIn("OCIO", os.environ)
-        self.assertTrue(os.environ["OCIO"].endswith("config.ocio"))
-        print(f"Frozen mode Verification: {os.environ['OCIO']}")
+        window = ModernMainWindow.__new__(ModernMainWindow)
+        window._ensure_bundled_ocio_config()
+
+        self.assertNotIn("OCIO", os.environ)
+        self.assertTrue(str(get_bundled_ocio_config_path()).endswith("config.ocio"))
+
+    def test_ocio_strategy_loads_bundled_config_when_env_var_is_invalid(self):
+        os.environ["OCIO"] = "C:/does/not/exist/config.ocio"
+
+        strategy = OCIOColorSpaceStrategy()
+
+        self.assertEqual(strategy.config_path, get_bundled_ocio_config_path())
+        self.assertIn("ACES - ACEScg", list(strategy.config.getColorSpaceNames()))
+        self.assertEqual(os.environ["OCIO"], "C:/does/not/exist/config.ocio")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Load RenderKit's bundled OCIO config directly for PyOpenColorIO and OpenImageIO instead of reading or setting the OCIO environment variable.
- Replace the UI startup env mutation with a bundled-config availability check.
- Update tests and usage docs to reflect that OCIO is left untouched.

Fixes #96

## Validation
- `uv --native-tls run --extra dev ruff check src\renderkit\processing\color_space.py src\renderkit\ui\main_window_logic.py src\renderkit\ui\main_window.py tests\test_ocio_env_setup.py tests\test_color_space.py`
- `uv --native-tls run --extra dev ruff format --check src\renderkit\processing\color_space.py src\renderkit\ui\main_window_logic.py src\renderkit\ui\main_window.py tests\test_ocio_env_setup.py tests\test_color_space.py`
- `uv --native-tls run --extra dev pytest`
- Targeted invalid-`OCIO` smoke: `LINEAR_TO_SRGB` conversion succeeded while `OCIO` pointed to `C:/does/not/exist/config.ocio`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OCIO color space conversions now use an embedded configuration file, eliminating dependency on the OCIO environment variable.

* **Documentation**
  * Updated usage guide to clarify that OCIO conversions use bundled configuration and the OCIO environment variable is not read or modified.

* **Tests**
  * Refreshed test coverage to validate bundled OCIO configuration behavior and environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->