### PR TITLE
[codex] Refactor conversion and UI orchestration

### DIFF
--- a/src/renderkit/core/converter.py
+++ b/src/renderkit/core/converter.py
@@ -3,11 +3,12 @@ import sys
 import threading
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
 from pathlib import Path
 from types import TracebackType
 from typing import Any, Optional
 
-from renderkit.core.config import ConversionConfig
+from renderkit.core.config import ContactSheetConfig, ConversionConfig
 from renderkit.core.sequence import FrameSequence, SequenceDetector
 from renderkit.exceptions import (
     ColorSpaceError,
@@ -26,6 +27,17 @@ from renderkit.processing.scaler import ImageScaler
 from renderkit.processing.video_encoder import VideoEncoder
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _FrameProcessingPlan:
+    """Resolved frame range and lookup data for conversion."""
+
+    all_frames: tuple[int, ...]
+    existing_frames: frozenset[int]
+    start_frame: int
+    end_frame: int
+    total_frames: int
 
 
 class _FramePrefetcher:
@@ -305,23 +317,12 @@ class SequenceConverter:
         logger.debug(f"Processing {len(frame_numbers)} frames...")
         if self.sequence is None:
             raise RuntimeError("Sequence must be detected before processing frames.")
-        sequence = self.sequence
 
-        all_frames, existing_frames, start_frame, end_frame, total_frames = self._build_frame_range(
-            frame_numbers
-        )
-
-        missing_count = total_frames - len(existing_frames)
-        if missing_count > 0:
-            logger.warning(
-                f"Detected {missing_count} missing frames in range {start_frame}-{end_frame}. "
-                f"Will use freeze-frame (hold last valid frame) for missing frames."
-            )
+        plan = self._build_frame_processing_plan(frame_numbers)
+        self._log_missing_frame_policy(plan)
 
         scaler = ImageScaler()
         success_count = 0
-        last_valid_buf: Any = None
-        prefetch_workers = max(1, self.config.prefetch_workers)
         contact_sheet_config = (
             self.config.contact_sheet_config if self.config.contact_sheet_mode else None
         )
@@ -333,7 +334,7 @@ class SequenceConverter:
 
         def _tick_progress(current_index: int) -> None:
             if progress_callback:
-                if progress_callback(current_index, total_frames) is False:
+                if progress_callback(current_index, plan.total_frames) is False:
                     logger.info("Conversion cancelled by progress callback")
                     raise ConversionCancelledError("Conversion cancelled by user")
             elif pbar is not None:
@@ -343,94 +344,37 @@ class SequenceConverter:
             if progress_callback is None and show_progress:
                 from tqdm import tqdm
 
-                pbar = tqdm(total=total_frames, desc="Converting frames")
+                pbar = tqdm(total=plan.total_frames, desc="Converting frames")
 
-            if prefetch_workers > 1:
-                thread_state = threading.local()
-                layers_for_cs = file_info.layers if contact_sheet_enabled else None
-
-                def _get_thread_resources(frame_path: Path) -> Any:
-                    reader = getattr(thread_state, "reader", None)
-                    if reader is None:
-                        reader = ImageReaderFactory.create_reader(
-                            frame_path, image_cache=get_shared_image_cache()
-                        )
-                        thread_state.reader = reader
-
-                    if not hasattr(thread_state, "color_converter"):
-                        thread_state.color_converter = ColorSpaceConverter(
-                            self.config.color_space_preset
-                        )
-
-                    if self.config.burnin_config and not hasattr(thread_state, "burnin_processor"):
-                        thread_state.burnin_processor = BurnInProcessor()
-
-                    if contact_sheet_enabled and not hasattr(
-                        thread_state, "contact_sheet_generator"
-                    ):
-                        assert contact_sheet_config is not None
-                        thread_state.contact_sheet_generator = ContactSheetGenerator(
-                            contact_sheet_config,
-                            reader=reader,
-                            layers=layers_for_cs,
-                            layer_map=self._layer_map,
-                        )
-
-                    return thread_state
-
-                def _prefetch_frame(frame_num: int) -> Any:
-                    frame_path = sequence.get_file_path(frame_num)
-                    resources = _get_thread_resources(frame_path)
-                    return self._prepare_frame_buf(
-                        frame_num,
-                        output_width,
-                        output_height,
-                        width,
-                        height,
-                        scaler,
-                        input_space,
-                        resources.reader,
-                        resources.color_converter,
-                        getattr(resources, "burnin_processor", None),
-                        contact_sheet_generator=getattr(resources, "contact_sheet_generator", None),
-                    )
-
-                with _FramePrefetcher(
-                    _prefetch_frame, frame_numbers, prefetch_workers
-                ) as prefetcher:
-                    for i, frame_num in enumerate(all_frames):
-                        _tick_progress(i)
-                        if frame_num in existing_frames:
-                            future = prefetcher.get_future(frame_num)
-                            result = future.result()
-                            last_valid_buf = result
-                            self._write_frame_buf(frame_num, result)
-                            success_count += 1
-                        else:
-                            if self._write_freeze_frame(frame_num, last_valid_buf, i):
-                                success_count += 1
+            if self._should_prefetch_frames():
+                success_count = self._process_prefetched_frame_plan(
+                    plan,
+                    frame_numbers,
+                    output_width,
+                    output_height,
+                    width,
+                    height,
+                    scaler,
+                    input_space,
+                    file_info,
+                    contact_sheet_config if contact_sheet_enabled else None,
+                    _tick_progress,
+                )
             else:
-                for i, frame_num in enumerate(all_frames):
-                    _tick_progress(i)
-                    if frame_num in existing_frames:
-                        result = self._process_single_frame_buf(
-                            frame_num,
-                            output_width,
-                            output_height,
-                            width,
-                            height,
-                            scaler,
-                            input_space,
-                            self.contact_sheet_generator if contact_sheet_enabled else None,
-                        )
-                        last_valid_buf = result
-                        success_count += 1
-                    else:
-                        if self._write_freeze_frame(frame_num, last_valid_buf, i):
-                            success_count += 1
+                success_count = self._process_sequential_frame_plan(
+                    plan,
+                    output_width,
+                    output_height,
+                    width,
+                    height,
+                    scaler,
+                    input_space,
+                    self.contact_sheet_generator if contact_sheet_enabled else None,
+                    _tick_progress,
+                )
 
             if progress_callback:
-                progress_callback(total_frames, total_frames)
+                progress_callback(plan.total_frames, plan.total_frames)
 
             if success_count == 0:
                 raise VideoEncodingError(
@@ -451,6 +395,198 @@ class SequenceConverter:
                         self.encoder.close()
                     except VideoEncodingError:
                         logger.exception("Video encoder finalization failed during cleanup.")
+
+    def _build_frame_processing_plan(self, frame_numbers: list[int]) -> _FrameProcessingPlan:
+        """Resolve conversion frame range metadata for processing."""
+        all_frames, existing_frames, start_frame, end_frame, total_frames = self._build_frame_range(
+            frame_numbers
+        )
+        return _FrameProcessingPlan(
+            all_frames=tuple(all_frames),
+            existing_frames=frozenset(existing_frames),
+            start_frame=start_frame,
+            end_frame=end_frame,
+            total_frames=total_frames,
+        )
+
+    def _log_missing_frame_policy(self, plan: _FrameProcessingPlan) -> None:
+        """Log freeze-frame policy when the resolved frame range has holes."""
+        missing_count = plan.total_frames - len(plan.existing_frames)
+        if missing_count <= 0:
+            return
+
+        logger.warning(
+            f"Detected {missing_count} missing frames in range "
+            f"{plan.start_frame}-{plan.end_frame}. "
+            f"Will use freeze-frame (hold last valid frame) for missing frames."
+        )
+
+    def _should_prefetch_frames(self) -> bool:
+        """Return whether frame preparation should use the threaded prefetch path."""
+        return max(1, self.config.prefetch_workers) > 1
+
+    def _process_prefetched_frame_plan(
+        self,
+        plan: _FrameProcessingPlan,
+        frame_numbers: list[int],
+        output_width: int,
+        output_height: int,
+        width: int,
+        height: int,
+        scaler: "ImageScaler",
+        input_space: Optional[str],
+        file_info: FileInfo,
+        contact_sheet_config: Optional[ContactSheetConfig],
+        tick_progress: Callable[[int], None],
+    ) -> int:
+        """Process a frame plan using worker-thread preparation and main-thread writes."""
+        prefetch_frame = self._create_prefetch_frame_fn(
+            output_width,
+            output_height,
+            width,
+            height,
+            scaler,
+            input_space,
+            file_info,
+            contact_sheet_config,
+        )
+
+        prefetch_workers = max(1, self.config.prefetch_workers)
+        with _FramePrefetcher(prefetch_frame, frame_numbers, prefetch_workers) as prefetcher:
+            return self._write_prefetched_frame_plan(plan, prefetcher, tick_progress)
+
+    def _create_prefetch_frame_fn(
+        self,
+        output_width: int,
+        output_height: int,
+        width: int,
+        height: int,
+        scaler: "ImageScaler",
+        input_space: Optional[str],
+        file_info: FileInfo,
+        contact_sheet_config: Optional[ContactSheetConfig],
+    ) -> Callable[[int], Any]:
+        """Create a worker-thread frame preparation callback."""
+        if self.sequence is None:
+            raise RuntimeError("Sequence must be detected before processing frames.")
+
+        sequence = self.sequence
+        thread_state = threading.local()
+        layers_for_cs = file_info.layers if contact_sheet_config is not None else None
+
+        def _prefetch_frame(frame_num: int) -> Any:
+            frame_path = sequence.get_file_path(frame_num)
+            resources = self._get_prefetch_thread_resources(
+                thread_state,
+                frame_path,
+                contact_sheet_config,
+                layers_for_cs,
+            )
+            return self._prepare_frame_buf(
+                frame_num,
+                output_width,
+                output_height,
+                width,
+                height,
+                scaler,
+                input_space,
+                resources.reader,
+                resources.color_converter,
+                getattr(resources, "burnin_processor", None),
+                contact_sheet_generator=getattr(resources, "contact_sheet_generator", None),
+            )
+
+        return _prefetch_frame
+
+    def _get_prefetch_thread_resources(
+        self,
+        thread_state: Any,
+        frame_path: Path,
+        contact_sheet_config: Optional[ContactSheetConfig],
+        layers_for_cs: Optional[list[str]],
+    ) -> Any:
+        """Return reusable frame-processing resources for the active prefetch thread."""
+        reader = getattr(thread_state, "reader", None)
+        if reader is None:
+            reader = ImageReaderFactory.create_reader(
+                frame_path, image_cache=get_shared_image_cache()
+            )
+            thread_state.reader = reader
+
+        if not hasattr(thread_state, "color_converter"):
+            thread_state.color_converter = ColorSpaceConverter(self.config.color_space_preset)
+
+        if self.config.burnin_config and not hasattr(thread_state, "burnin_processor"):
+            thread_state.burnin_processor = BurnInProcessor()
+
+        if contact_sheet_config is not None and not hasattr(
+            thread_state, "contact_sheet_generator"
+        ):
+            thread_state.contact_sheet_generator = ContactSheetGenerator(
+                contact_sheet_config,
+                reader=reader,
+                layers=layers_for_cs,
+                layer_map=self._layer_map,
+            )
+
+        return thread_state
+
+    def _write_prefetched_frame_plan(
+        self,
+        plan: _FrameProcessingPlan,
+        prefetcher: _FramePrefetcher,
+        tick_progress: Callable[[int], None],
+    ) -> int:
+        """Write prefetched frames and freeze-frames in presentation order."""
+        success_count = 0
+        last_valid_buf: Any = None
+        for index, frame_num in enumerate(plan.all_frames):
+            tick_progress(index)
+            if frame_num in plan.existing_frames:
+                future = prefetcher.get_future(frame_num)
+                result = future.result()
+                last_valid_buf = result
+                self._write_frame_buf(frame_num, result)
+                success_count += 1
+            elif self._write_freeze_frame(frame_num, last_valid_buf, index):
+                success_count += 1
+
+        return success_count
+
+    def _process_sequential_frame_plan(
+        self,
+        plan: _FrameProcessingPlan,
+        output_width: int,
+        output_height: int,
+        width: int,
+        height: int,
+        scaler: "ImageScaler",
+        input_space: Optional[str],
+        contact_sheet_generator: Optional[ContactSheetGenerator],
+        tick_progress: Callable[[int], None],
+    ) -> int:
+        """Process a frame plan in frame order on the current thread."""
+        success_count = 0
+        last_valid_buf: Any = None
+        for index, frame_num in enumerate(plan.all_frames):
+            tick_progress(index)
+            if frame_num in plan.existing_frames:
+                result = self._process_single_frame_buf(
+                    frame_num,
+                    output_width,
+                    output_height,
+                    width,
+                    height,
+                    scaler,
+                    input_space,
+                    contact_sheet_generator,
+                )
+                last_valid_buf = result
+                success_count += 1
+            elif self._write_freeze_frame(frame_num, last_valid_buf, index):
+                success_count += 1
+
+        return success_count
 
     def _prepare_frame_buf(
         self,

--- a/src/renderkit/ui/main_window_logic.py
+++ b/src/renderkit/ui/main_window_logic.py
@@ -14,6 +14,7 @@ from renderkit.core.config import (
     BurnInConfig,
     BurnInElement,
     ContactSheetConfig,
+    ConversionConfig,
     ConversionConfigBuilder,
 )
 from renderkit.exceptions import RenderKitError
@@ -1615,6 +1616,119 @@ class MainWindowLogicMixin:
         else:
             self._ocio_role_display_map = {}
 
+    def _selected_codec_id(self) -> str:
+        """Return the codec id selected in the UI."""
+        codec_index = self.codec_combo.currentIndex()
+        return self._codec_map.get(codec_index, "libx264")
+
+    def _resolve_encoder_for_conversion(self, codec_id: str) -> Optional[str]:
+        """Validate and resolve the codec that should be used for conversion."""
+        encoder_probe = get_encoder_probe_result()
+        available_encoders = set(encoder_probe.encoders)
+        resolved_codec, fallback_warning = select_available_encoder(codec_id, available_encoders)
+
+        if encoder_probe.failed:
+            QMessageBox.warning(
+                self,
+                "Encoder Probe Failed",
+                (
+                    "Unable to validate FFmpeg encoder availability.\n\n"
+                    f"{encoder_probe.error}\n\n"
+                    f"RenderKit will attempt to use '{resolved_codec}'."
+                ),
+            )
+            logger.warning(
+                "Skipping FFmpeg encoder availability validation because probing failed: %s. "
+                "Attempting '%s'.",
+                encoder_probe.error,
+                resolved_codec,
+            )
+        elif resolved_codec not in encoder_probe.encoders:
+            available = ", ".join(sorted(encoder_probe.encoders)) or "none"
+            QMessageBox.critical(
+                self,
+                "Encoder Unavailable",
+                (
+                    f"Requested encoder '{codec_id}' is not available.\n\n"
+                    f"Available encoders: {available}"
+                ),
+            )
+            return None
+
+        if fallback_warning:
+            QMessageBox.warning(
+                self,
+                "Encoder Unavailable",
+                f"{fallback_warning}\n\nUsing '{resolved_codec}' for this conversion.",
+            )
+            logger.warning(fallback_warning)
+            for index, mapped_codec in self._codec_map.items():
+                if mapped_codec == resolved_codec:
+                    self.codec_combo.setCurrentIndex(index)
+                    break
+
+        return resolved_codec
+
+    def _build_contact_sheet_config_for_conversion(self) -> Optional[ContactSheetConfig]:
+        """Build contact-sheet settings for conversion from the current UI state."""
+        if not self.cs_enable_check.isChecked():
+            return None
+
+        layer_width = None
+        layer_height = None
+        if not self.keep_resolution_check.isChecked():
+            layer_width = self.width_spin.value()
+            layer_height = self.height_spin.value()
+
+        show_labels = self.burnin_enable_check.isChecked() and self.burnin_layer_check.isChecked()
+        return ContactSheetConfig(
+            columns=self.cs_columns_spin.value(),
+            padding=self.cs_padding_spin.value(),
+            show_labels=show_labels,
+            font_size=self.burnin_font_size_spin.value(),
+            layer_width=layer_width,
+            layer_height=layer_height,
+        )
+
+    def _build_conversion_config_from_ui(
+        self, output_path: Path, resolved_codec: str
+    ) -> ConversionConfig:
+        """Build conversion configuration from widget state without starting work."""
+        config_builder = (
+            ConversionConfigBuilder()
+            .with_input_pattern(self.input_pattern_combo.currentText().strip())
+            .with_output_path(str(output_path))
+            .with_fps(float(self.fps_spin.value()))
+            .with_quality(self.quality_slider.value())
+            .with_layer(self.layer_combo.currentText())
+            .with_codec(resolved_codec)
+        )
+        if hasattr(self, "prefetch_workers_spin"):
+            config_builder.with_prefetch_workers(self.prefetch_workers_spin.value())
+
+        preset, input_space = self._get_current_color_space_config()
+        config_builder.with_color_space_preset(preset)
+        if input_space:
+            config_builder.with_explicit_input_color_space(input_space)
+
+        if not self.keep_resolution_check.isChecked():
+            config_builder.with_resolution(self.width_spin.value(), self.height_spin.value())
+
+        start_frame = self.start_frame_spin.value()
+        end_frame = self.end_frame_spin.value()
+        if start_frame > 0 and end_frame > 0 and end_frame >= start_frame:
+            config_builder.with_frame_range(start_frame, end_frame)
+
+        cs_config = self._build_contact_sheet_config_for_conversion()
+        if cs_config is not None:
+            config_builder.with_contact_sheet(True, cs_config)
+
+        burnin_config = self._build_burnin_config(include_layer=cs_config is None)
+        if burnin_config is not None:
+            config_builder.with_burnin(burnin_config)
+
+        return config_builder.build()
+
     def _start_conversion(self) -> None:
         """Start the conversion process."""
         # Validate inputs
@@ -1641,110 +1755,10 @@ class MainWindowLogicMixin:
 
         # Build configuration
         try:
-            config_builder = (
-                ConversionConfigBuilder()
-                .with_input_pattern(self.input_pattern_combo.currentText().strip())
-                .with_output_path(str(output_path))
-                .with_fps(float(self.fps_spin.value()))
-                .with_quality(self.quality_slider.value())
-                .with_layer(self.layer_combo.currentText())
-            )
-            if hasattr(self, "prefetch_workers_spin"):
-                config_builder.with_prefetch_workers(self.prefetch_workers_spin.value())
-
-            # Color space
-            preset, input_space = self._get_current_color_space_config()
-
-            config_builder.with_color_space_preset(preset)
-            if input_space:
-                config_builder.with_explicit_input_color_space(input_space)
-
-            # Resolution
-            if not self.keep_resolution_check.isChecked():
-                config_builder.with_resolution(self.width_spin.value(), self.height_spin.value())
-
-            # Codec
-            codec_index = self.codec_combo.currentIndex()
-            codec_id = self._codec_map.get(codec_index, "libx264")
-            encoder_probe = get_encoder_probe_result()
-            available_encoders = set(encoder_probe.encoders)
-            resolved_codec, fallback_warning = select_available_encoder(
-                codec_id, available_encoders
-            )
-            if encoder_probe.failed:
-                QMessageBox.warning(
-                    self,
-                    "Encoder Probe Failed",
-                    (
-                        "Unable to validate FFmpeg encoder availability.\n\n"
-                        f"{encoder_probe.error}\n\n"
-                        f"RenderKit will attempt to use '{resolved_codec}'."
-                    ),
-                )
-                logger.warning(
-                    "Skipping FFmpeg encoder availability validation because probing failed: %s. "
-                    "Attempting '%s'.",
-                    encoder_probe.error,
-                    resolved_codec,
-                )
-            elif resolved_codec not in encoder_probe.encoders:
-                available = ", ".join(sorted(encoder_probe.encoders)) or "none"
-                QMessageBox.critical(
-                    self,
-                    "Encoder Unavailable",
-                    (
-                        f"Requested encoder '{codec_id}' is not available.\n\n"
-                        f"Available encoders: {available}"
-                    ),
-                )
+            resolved_codec = self._resolve_encoder_for_conversion(self._selected_codec_id())
+            if resolved_codec is None:
                 return
-            if fallback_warning:
-                QMessageBox.warning(
-                    self,
-                    "Encoder Unavailable",
-                    f"{fallback_warning}\n\nUsing '{resolved_codec}' for this conversion.",
-                )
-                logger.warning(fallback_warning)
-                for idx, mapped_codec in self._codec_map.items():
-                    if mapped_codec == resolved_codec:
-                        self.codec_combo.setCurrentIndex(idx)
-                        break
-            config_builder.with_codec(resolved_codec)
-
-            # Frame range
-            start_frame = self.start_frame_spin.value()
-            end_frame = self.end_frame_spin.value()
-            if start_frame > 0 and end_frame > 0 and end_frame >= start_frame:
-                config_builder.with_frame_range(start_frame, end_frame)
-
-            # Contact Sheet Mode
-            if self.cs_enable_check.isChecked():
-                layer_width = None
-                layer_height = None
-                if not self.keep_resolution_check.isChecked():
-                    layer_width = self.width_spin.value()
-                    layer_height = self.height_spin.value()
-
-                show_labels = (
-                    self.burnin_enable_check.isChecked() and self.burnin_layer_check.isChecked()
-                )
-                cs_config = ContactSheetConfig(
-                    columns=self.cs_columns_spin.value(),
-                    padding=self.cs_padding_spin.value(),
-                    show_labels=show_labels,
-                    font_size=self.burnin_font_size_spin.value(),
-                    layer_width=layer_width,
-                    layer_height=layer_height,
-                )
-                config_builder.with_contact_sheet(True, cs_config)
-
-            burnin_config = self._build_burnin_config(
-                include_layer=not self.cs_enable_check.isChecked()
-            )
-            if burnin_config is not None:
-                config_builder.with_burnin(burnin_config)
-
-            config = config_builder.build()
+            config = self._build_conversion_config_from_ui(output_path, resolved_codec)
 
         except (RenderKitError, OSError, RuntimeError, ValueError) as e:
             QMessageBox.critical(self, "Configuration Error", f"Error building configuration:\n{e}")

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -363,6 +363,46 @@ class TestSequenceConverterFailures:
 
         assert encoder.closed
 
+    def test_process_sequential_frame_plan_uses_freeze_frame_policy(self) -> None:
+        """Sequential frame-plan processing should write missing frames from the last valid frame."""
+
+        class RecordingEncoder:
+            def __init__(self) -> None:
+                self.frames = []
+
+            def write_frame(self, buf) -> None:
+                self.frames.append(buf.name)
+
+        class NamedBuf:
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+        converter = self._converter()
+        converter.encoder = RecordingEncoder()
+        plan = converter._build_frame_processing_plan([1, 3])
+
+        def process_frame(frame_num, *args, **kwargs):
+            buf = NamedBuf(str(frame_num))
+            converter._write_frame_buf(frame_num, buf)
+            return buf
+
+        converter._process_single_frame_buf = process_frame
+
+        success_count = converter._process_sequential_frame_plan(
+            plan,
+            output_width=100,
+            output_height=100,
+            width=100,
+            height=100,
+            scaler=object(),
+            input_space=None,
+            contact_sheet_generator=None,
+            tick_progress=lambda _index: None,
+        )
+
+        assert success_count == 3
+        assert converter.encoder.frames == ["1", "1", "3"]
+
 
 class TestSequenceConverterProgress:
     """Tests for CLI progress-bar behavior."""

--- a/tests/test_ui_logic_preview.py
+++ b/tests/test_ui_logic_preview.py
@@ -2,7 +2,10 @@
 
 from pathlib import Path
 
+import pytest
+
 from renderkit.processing.color_space import ColorSpacePreset
+from renderkit.processing.video_encoder import EncoderProbeResult
 from renderkit.ui import main_window_logic
 
 
@@ -23,11 +26,25 @@ class _DummyCheck:
 
 
 class _DummyCombo:
-    def __init__(self, text: str) -> None:
+    def __init__(self, text: str, index: int = 0) -> None:
         self._text = text
+        self._index = index
 
     def currentText(self) -> str:
         return self._text
+
+    def current_index(self) -> int:
+        return self._index
+
+    def set_current_index(self, index: int) -> None:
+        self._index = index
+
+    def __getattr__(self, name: str):
+        if name == "currentIndex":
+            return self.current_index
+        if name == "setCurrentIndex":
+            return self.set_current_index
+        raise AttributeError(name)
 
 
 class _DummyPreviewWidget:
@@ -51,6 +68,13 @@ class _DummyWindow(main_window_logic.MainWindowLogicMixin):
         self.layer_combo = _DummyCombo("RGBA")
         self.color_space_combo = _DummyCombo("Linear")
         self.fps_spin = _DummyValue(24)
+        self.input_pattern_combo = _DummyCombo("render.%04d.exr")
+        self.quality_slider = _DummyValue(8)
+        self.start_frame_spin = _DummyValue(1001)
+        self.end_frame_spin = _DummyValue(1010)
+        self.prefetch_workers_spin = _DummyValue(3)
+        self.codec_combo = _DummyCombo("H.264", index=0)
+        self._codec_map = {0: "libx264", 1: "libx265"}
         self.burnin_enable_check = _DummyCheck(burnin_enabled)
         self.burnin_frame_check = _DummyCheck(True)
         self.burnin_layer_check = _DummyCheck(True)
@@ -116,3 +140,102 @@ def test_load_preview_from_path_builds_burnin_config(tmp_path: Path) -> None:
     assert metadata is not None
     assert metadata["frame"] == 100
     assert metadata["file"] == "render.0100.exr"
+
+
+def test_build_conversion_config_from_ui_is_worker_free(tmp_path: Path) -> None:
+    """Ensure UI config assembly can be tested without starting a worker."""
+    output_path = tmp_path / "out.mp4"
+    window = _DummyWindow(cs_enabled=True, burnin_enabled=True)
+    window.keep_resolution_check = _DummyCheck(False)
+
+    config = window._build_conversion_config_from_ui(output_path, "libx265")
+
+    assert config.input_pattern == "render.%04d.exr"
+    assert config.output_path == str(output_path)
+    assert config.codec == "libx265"
+    assert config.fps == pytest.approx(24.0)
+    assert config.quality == 8
+    assert config.prefetch_workers == 3
+    assert config.start_frame == 1001
+    assert config.end_frame == 1010
+    assert config.width == 1920
+    assert config.height == 1080
+    assert config.explicit_input_color_space == "Linear"
+
+    assert config.contact_sheet_mode is True
+    assert config.contact_sheet_config is not None
+    assert config.contact_sheet_config.columns == 4
+    assert config.contact_sheet_config.layer_width == 1920
+    assert config.contact_sheet_config.layer_height == 1080
+    assert config.contact_sheet_config.show_labels is True
+
+    assert config.burnin_config is not None
+    templates = [element.text_template for element in config.burnin_config.elements]
+    assert templates == ["Frame: {frame}", "FPS: {fps:.2f}"]
+
+
+def test_resolve_encoder_for_conversion_falls_back(monkeypatch) -> None:
+    """Ensure encoder fallback is handled without starting conversion."""
+    warnings = []
+    window = _DummyWindow(cs_enabled=False)
+
+    monkeypatch.setattr(
+        main_window_logic,
+        "get_encoder_probe_result",
+        lambda: EncoderProbeResult(frozenset({"libx265"})),
+    )
+    monkeypatch.setattr(
+        main_window_logic.QMessageBox,
+        "warning",
+        lambda *args, **kwargs: warnings.append(args),
+    )
+
+    resolved_codec = window._resolve_encoder_for_conversion("libx264")
+
+    assert resolved_codec == "libx265"
+    assert window.codec_combo.currentIndex() == 1
+    assert warnings
+
+
+def test_resolve_encoder_for_conversion_rejects_unavailable_codec(monkeypatch) -> None:
+    """Ensure confirmed encoder absence aborts before building config."""
+    critical_messages = []
+    window = _DummyWindow(cs_enabled=False)
+
+    monkeypatch.setattr(
+        main_window_logic,
+        "get_encoder_probe_result",
+        lambda: EncoderProbeResult(frozenset({"vp9"})),
+    )
+    monkeypatch.setattr(
+        main_window_logic.QMessageBox,
+        "critical",
+        lambda *args, **kwargs: critical_messages.append(args),
+    )
+
+    resolved_codec = window._resolve_encoder_for_conversion("libx264")
+
+    assert resolved_codec is None
+    assert critical_messages
+
+
+def test_resolve_encoder_for_conversion_allows_probe_failure(monkeypatch) -> None:
+    """Ensure probe failures remain warning-only for conversion startup."""
+    warnings = []
+    window = _DummyWindow(cs_enabled=False)
+
+    monkeypatch.setattr(
+        main_window_logic,
+        "get_encoder_probe_result",
+        lambda: EncoderProbeResult(frozenset(), error="ffmpeg missing"),
+    )
+    monkeypatch.setattr(
+        main_window_logic.QMessageBox,
+        "warning",
+        lambda *args, **kwargs: warnings.append(args),
+    )
+
+    resolved_codec = window._resolve_encoder_for_conversion("libx264")
+
+    assert resolved_codec == "libx264"
+    assert warnings


### PR DESCRIPTION
## Summary
- Extract converter frame planning and frame-plan execution helpers so `_process_frames` no longer owns scheduling and missing-frame write policy inline.
- Extract UI encoder resolution and conversion config assembly helpers so config construction can be tested without starting a `ConversionWorker`.
- Add focused tests for freeze-frame behavior, encoder resolution, and worker-free UI config construction.

## Why
Issue #83 identified central conversion and UI startup methods as high-risk orchestration points. This keeps behavior intact while splitting deterministic pieces into smaller helpers with coverage.

## Validation
- `uv --native-tls run --extra dev pytest` (151 passed, 9 skipped)
- `uv --native-tls run ruff check` (passed)
- `uv --native-tls run --extra dev pytest tests\test_converter.py tests\test_ui_logic_preview.py` (29 passed)
- `uv --native-tls run ruff check src\renderkit\core\converter.py src\renderkit\ui\main_window_logic.py tests\test_converter.py tests\test_ui_logic_preview.py` (passed)

Closes #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Frame processing pipeline restructured for improved stability during conversions

* **Bug Fixes**
  * Codec selection validation enhanced with improved error handling and automatic fallback support
  * Missing frames now automatically filled using the previous frame as fallback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->