### PR TITLE
Share preview frame preparation pipeline

### DIFF
--- a/src/renderkit/core/converter.py
+++ b/src/renderkit/core/converter.py
@@ -11,7 +11,6 @@ from typing import Any, Optional
 from renderkit.core.config import ContactSheetConfig, ConversionConfig
 from renderkit.core.sequence import FrameSequence, SequenceDetector
 from renderkit.exceptions import (
-    ColorSpaceError,
     ConversionCancelledError,
     ImageReadError,
     SequenceDetectionError,
@@ -23,6 +22,7 @@ from renderkit.io.oiio_cache import get_shared_image_cache
 from renderkit.processing.burnin import BurnInProcessor
 from renderkit.processing.color_space import ColorSpaceConverter, ColorSpacePreset
 from renderkit.processing.contact_sheet import ContactSheetGenerator
+from renderkit.processing.frame_pipeline import FramePreparationOptions, prepare_frame_buffer
 from renderkit.processing.scaler import ImageScaler
 from renderkit.processing.video_encoder import VideoEncoder
 
@@ -606,63 +606,26 @@ class SequenceConverter:
         if self.sequence is None:
             raise RuntimeError("Sequence must be detected before preparing frames.")
         frame_path = self.sequence.get_file_path(frame_num)
-
-        if contact_sheet_generator:
-            try:
-                buf = contact_sheet_generator.composite_layers(frame_path)
-            except ImageReadError as e:
-                raise ImageReadError(
-                    f"Failed to build contact sheet for frame {frame_num}: {e}"
-                ) from e
-            except (RuntimeError, TypeError, ValueError) as e:
-                raise VideoEncodingError(
-                    f"Failed to build contact sheet for frame {frame_num}: {e}"
-                ) from e
-            spec = buf.spec()
-            width, height = spec.width, spec.height
-        else:
-            try:
-                buf = reader.read_imagebuf(
-                    frame_path,
-                    layer=self.config.layer,
-                    layer_map=self._layer_map,
-                )
-            except ImageReadError as e:
-                raise ImageReadError(f"Failed to read frame {frame_num}: {e}") from e
-
-        try:
-            buf = color_converter.convert_buf(buf, input_space=input_space)
-        except ColorSpaceError as e:
-            raise ColorSpaceError(
-                f"Color space conversion failed for frame {frame_num}: {e}"
-            ) from e
-
-        if output_width != width or output_height != height:
-            try:
-                buf = scaler.scale_buf(buf, output_width, output_height)
-            except (RuntimeError, TypeError, ValueError) as e:
-                raise VideoEncodingError(f"Failed to scale frame {frame_num}: {e}") from e
-
-        if self.config.burnin_config and burnin_processor:
-            try:
-                metadata = {
-                    "frame": frame_num,
-                    "file": frame_path.name,
-                    "fps": self.config.fps,
-                    "layer": self.config.layer or "RGBA",
-                    "colorspace": input_space or "Unknown",
-                }
-                buf = burnin_processor.apply_burnins(
-                    buf,
-                    metadata,
-                    self.config.burnin_config,
-                )
-            except (RuntimeError, TypeError, ValueError) as e:
-                raise VideoEncodingError(
-                    f"Failed to apply burn-ins for frame {frame_num}: {e}"
-                ) from e
-
-        return buf
+        return prepare_frame_buffer(
+            FramePreparationOptions(
+                frame_path=frame_path,
+                frame_num=frame_num,
+                output_width=output_width,
+                output_height=output_height,
+                source_width=width,
+                source_height=height,
+                scaler=scaler,
+                input_space=input_space,
+                reader=reader,
+                color_converter=color_converter,
+                burnin_processor=burnin_processor,
+                burnin_config=self.config.burnin_config,
+                contact_sheet_generator=contact_sheet_generator,
+                layer=self.config.layer,
+                layer_map=self._layer_map,
+                fps=self.config.fps,
+            )
+        ).buf
 
     def _build_frame_range(
         self, frame_numbers: list[int]

--- a/src/renderkit/processing/frame_pipeline.py
+++ b/src/renderkit/processing/frame_pipeline.py
@@ -1,0 +1,257 @@
+"""Shared ImageBuf frame preparation for rendering and previews."""
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import OpenImageIO as oiio
+
+from renderkit.core.config import BurnInConfig, ContactSheetConfig
+from renderkit.exceptions import ColorSpaceError, ImageReadError, VideoEncodingError
+from renderkit.io.image_reader import ImageReader, ImageReaderFactory, LayerMapEntry
+from renderkit.io.oiio_cache import get_shared_image_cache
+from renderkit.processing.burnin import BurnInProcessor
+from renderkit.processing.color_space import ColorSpaceConverter
+from renderkit.processing.contact_sheet import ContactSheetGenerator
+from renderkit.processing.scaler import ImageScaler
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PreparedFrameBuffer:
+    """Prepared frame ImageBuf and the scale applied during preparation."""
+
+    buf: Any
+    applied_scale: float = 1.0
+
+
+@dataclass(frozen=True)
+class FramePreparationOptions:
+    """Options for shared ImageBuf frame preparation."""
+
+    frame_path: Path
+    frame_num: int
+    output_width: Optional[int]
+    output_height: Optional[int]
+    source_width: Optional[int]
+    source_height: Optional[int]
+    scaler: ImageScaler
+    input_space: Optional[str]
+    color_converter: ColorSpaceConverter
+    reader: Optional[ImageReader] = None
+    layer: Optional[str] = None
+    layer_map: Optional[dict[str, LayerMapEntry]] = None
+    fps: Optional[float] = None
+    burnin_processor: Optional[BurnInProcessor] = None
+    burnin_config: Optional[BurnInConfig] = None
+    burnin_metadata: Optional[dict[str, Any]] = None
+    burnin_config_adapter: Optional["BurnInConfigAdapter"] = None
+    contact_sheet_generator: Optional[ContactSheetGenerator] = None
+    contact_sheet_config: Optional[ContactSheetConfig] = None
+    output_scale: float = 1.0
+
+
+BurnInConfigAdapter = Callable[[BurnInConfig, float, int], BurnInConfig]
+
+
+def expand_data_channels_to_rgb(buf: oiio.ImageBuf) -> oiio.ImageBuf:
+    """Return a grayscale RGB buffer from the first channel of a data buffer."""
+    display_buf = oiio.ImageBufAlgo.channels(buf, (0, 0, 0), ("R", "G", "B"))
+    if display_buf.has_error:
+        raise ValueError(f"Failed to prepare data-channel frame: {display_buf.geterror()}")
+    return display_buf
+
+
+def prepare_frame_buffer(options: FramePreparationOptions) -> PreparedFrameBuffer:
+    """Read and prepare a single frame ImageBuf using the shared pipeline.
+
+    Args:
+        options: Frame preparation options.
+
+    Returns:
+        Prepared frame buffer and applied scale.
+    """
+    reader = _resolve_reader(options)
+    buf = _read_source_buffer(options, reader)
+
+    spec = buf.spec()
+    source_width, source_height = _resolve_source_size(options, spec)
+    buf = _apply_color_or_data_channel_policy(options, buf)
+    target_width, target_height = _resolve_target_size(options, spec)
+    buf, applied_scale = _apply_scaling(
+        options,
+        buf,
+        source_width,
+        source_height,
+        target_width,
+        target_height,
+    )
+    buf = _apply_burnins(options, buf, applied_scale)
+
+    return PreparedFrameBuffer(buf=buf, applied_scale=applied_scale)
+
+
+def _resolve_reader(options: FramePreparationOptions) -> ImageReader:
+    if options.reader is not None:
+        return options.reader
+    return ImageReaderFactory.create_reader(
+        options.frame_path, image_cache=get_shared_image_cache()
+    )
+
+
+def _read_source_buffer(
+    options: FramePreparationOptions,
+    reader: ImageReader,
+) -> oiio.ImageBuf:
+    if _contact_sheet_enabled(options):
+        generator = options.contact_sheet_generator or ContactSheetGenerator(
+            options.contact_sheet_config,
+            reader=reader,
+            layer_map=options.layer_map,
+        )
+        try:
+            return generator.composite_layers(options.frame_path)
+        except ImageReadError as e:
+            raise ImageReadError(
+                f"Failed to build contact sheet for frame {options.frame_num}: {e}"
+            ) from e
+        except (RuntimeError, TypeError, ValueError) as e:
+            raise VideoEncodingError(
+                f"Failed to build contact sheet for frame {options.frame_num}: {e}"
+            ) from e
+
+    try:
+        return reader.read_imagebuf(
+            options.frame_path,
+            layer=options.layer,
+            layer_map=options.layer_map,
+        )
+    except ImageReadError as e:
+        raise ImageReadError(f"Failed to read frame {options.frame_num}: {e}") from e
+
+
+def _contact_sheet_enabled(options: FramePreparationOptions) -> bool:
+    return options.contact_sheet_generator is not None or options.contact_sheet_config is not None
+
+
+def _resolve_source_size(
+    options: FramePreparationOptions,
+    spec: oiio.ImageSpec,
+) -> tuple[int, int]:
+    if _contact_sheet_enabled(options):
+        return spec.width, spec.height
+    return options.source_width or spec.width, options.source_height or spec.height
+
+
+def _apply_color_or_data_channel_policy(
+    options: FramePreparationOptions,
+    buf: oiio.ImageBuf,
+) -> oiio.ImageBuf:
+    spec = buf.spec()
+
+    if getattr(spec, "nchannels", 3) in (3, 4):
+        try:
+            return options.color_converter.convert_buf(buf, input_space=options.input_space)
+        except ColorSpaceError as e:
+            raise ColorSpaceError(
+                f"Color space conversion failed for frame {options.frame_num}: {e}"
+            ) from e
+
+    logger.debug(
+        "Skipping color conversion for non-RGB frame buffer. frame=%s channels=%s",
+        options.frame_num,
+        spec.nchannels,
+    )
+    try:
+        return expand_data_channels_to_rgb(buf)
+    except (RuntimeError, TypeError, ValueError) as e:
+        raise VideoEncodingError(
+            f"Failed to prepare data-channel frame {options.frame_num}: {e}"
+        ) from e
+
+
+def _resolve_target_size(
+    options: FramePreparationOptions,
+    spec: oiio.ImageSpec,
+) -> tuple[int, int]:
+    target_width = options.output_width
+    target_height = options.output_height
+    if target_width is None or target_height is None:
+        scale = min(1.0, max(0.0, options.output_scale))
+        target_width = max(1, int(spec.width * scale))
+        target_height = max(1, int(spec.height * scale))
+    return target_width, target_height
+
+
+def _apply_scaling(
+    options: FramePreparationOptions,
+    buf: oiio.ImageBuf,
+    source_width: int,
+    source_height: int,
+    target_width: int,
+    target_height: int,
+) -> tuple[oiio.ImageBuf, float]:
+    applied_scale = 1.0
+    if target_width != source_width or target_height != source_height:
+        try:
+            buf = options.scaler.scale_buf(buf, target_width, target_height)
+        except (RuntimeError, TypeError, ValueError) as e:
+            raise VideoEncodingError(f"Failed to scale frame {options.frame_num}: {e}") from e
+        scaled_spec = buf.spec()
+        applied_scale = min(
+            scaled_spec.width / float(source_width),
+            scaled_spec.height / float(source_height),
+        )
+    return buf, applied_scale
+
+
+def _apply_burnins(
+    options: FramePreparationOptions,
+    buf: oiio.ImageBuf,
+    applied_scale: float,
+) -> oiio.ImageBuf:
+    if not options.burnin_config or not options.burnin_processor:
+        return buf
+
+    try:
+        active_config = _resolve_burnin_config(options, buf, applied_scale)
+        metadata = options.burnin_metadata or _default_burnin_metadata(options)
+        return options.burnin_processor.apply_burnins(
+            buf,
+            metadata,
+            active_config,
+        )
+    except (RuntimeError, TypeError, ValueError) as e:
+        raise VideoEncodingError(
+            f"Failed to apply burn-ins for frame {options.frame_num}: {e}"
+        ) from e
+
+
+def _resolve_burnin_config(
+    options: FramePreparationOptions,
+    buf: oiio.ImageBuf,
+    applied_scale: float,
+) -> BurnInConfig:
+    if options.burnin_config_adapter is None:
+        assert options.burnin_config is not None
+        return options.burnin_config
+
+    assert options.burnin_config is not None
+    return options.burnin_config_adapter(
+        options.burnin_config,
+        applied_scale,
+        buf.spec().width,
+    )
+
+
+def _default_burnin_metadata(options: FramePreparationOptions) -> dict[str, Any]:
+    return {
+        "frame": options.frame_num,
+        "file": options.frame_path.name,
+        "fps": options.fps,
+        "layer": options.layer or "RGBA",
+        "colorspace": options.input_space or "Unknown",
+    }

--- a/src/renderkit/ui/widgets.py
+++ b/src/renderkit/ui/widgets.py
@@ -10,9 +10,13 @@ import OpenImageIO as oiio
 
 from renderkit.core.config import BurnInConfig, BurnInElement, ContactSheetConfig
 from renderkit.exceptions import RenderKitError
-from renderkit.io.image_reader import ImageReaderFactory
-from renderkit.io.oiio_cache import get_shared_image_cache
 from renderkit.processing.color_space import ColorSpaceConverter, ColorSpacePreset
+from renderkit.processing.frame_pipeline import (
+    FramePreparationOptions,
+    expand_data_channels_to_rgb,
+    prepare_frame_buffer,
+)
+from renderkit.processing.scaler import ImageScaler
 from renderkit.ui.icons import icon_manager
 from renderkit.ui.qt_compat import (
     QApplication,
@@ -84,10 +88,7 @@ def _prepare_buf_for_preview_display(
             "Skipping color conversion for non-RGB preview buffer. channels=%s",
             spec.nchannels,
         )
-        display_buf = oiio.ImageBufAlgo.channels(buf, (0, 0, 0), ("R", "G", "B"))
-        if display_buf.has_error:
-            raise ValueError(f"Failed to prepare data-channel preview: {display_buf.geterror()}")
-        return display_buf
+        return expand_data_channels_to_rgb(buf)
 
     converter = ColorSpaceConverter(color_space)
     return converter.convert_buf(buf, input_space=input_space)
@@ -134,54 +135,38 @@ class PreviewWorker(QThread):
     def run(self) -> None:
         """Load and process preview image."""
         try:
-            if self.cs_config:
-                from renderkit.processing.contact_sheet import ContactSheetGenerator
+            from renderkit.processing.burnin import BurnInProcessor
 
-                generator = ContactSheetGenerator(self.cs_config)
-                buf = generator.composite_layers(self.file_path)
-            else:
-                reader = ImageReaderFactory.create_reader(
-                    self.file_path, image_cache=get_shared_image_cache()
-                )
-                buf = reader.read_imagebuf(self.file_path, layer=self.layer)
-
-            applied_preview_scale = 1.0
-
-            # Apply preview scale
-            if self.preview_scale < 1.0:
-                spec = buf.spec()
-                h, w = spec.height, spec.width
-                new_w = max(1, int(w * self.preview_scale))
-                new_h = max(1, int(h * self.preview_scale))
-                from renderkit.processing.scaler import ImageScaler
-
-                buf = ImageScaler.scale_buf(buf, width=new_w, height=new_h)
-                scaled_spec = buf.spec()
-                applied_preview_scale = min(
-                    scaled_spec.width / float(w),
-                    scaled_spec.height / float(h),
-                )
-
-            buf = _prepare_buf_for_preview_display(
-                buf,
-                self.color_space,
-                self.input_space,
+            burnin_processor = (
+                BurnInProcessor()
+                if self.burnin_config is not None and self.burnin_metadata is not None
+                else None
             )
-
-            if self.burnin_config and self.burnin_metadata:
-                from renderkit.processing.burnin import BurnInProcessor
-
-                processor = BurnInProcessor()
-                burnin_config = _scaled_burnin_config_for_preview(
-                    self.burnin_config,
-                    applied_preview_scale,
-                    buf.spec().width,
+            prepared = prepare_frame_buffer(
+                FramePreparationOptions(
+                    frame_path=self.file_path,
+                    frame_num=0,
+                    output_width=None,
+                    output_height=None,
+                    source_width=None,
+                    source_height=None,
+                    scaler=ImageScaler(),
+                    input_space=self.input_space,
+                    color_converter=ColorSpaceConverter(self.color_space),
+                    layer=self.layer,
+                    burnin_processor=burnin_processor,
+                    burnin_config=self.burnin_config if self.burnin_metadata else None,
+                    burnin_metadata=self.burnin_metadata,
+                    burnin_config_adapter=_scaled_burnin_config_for_preview,
+                    contact_sheet_config=self.cs_config,
+                    output_scale=self.preview_scale,
                 )
-                buf = processor.apply_burnins(
-                    buf,
-                    self.burnin_metadata,
-                    burnin_config,
-                )
+            )
+            buf = _prepare_buf_for_preview_display(
+                prepared.buf,
+                ColorSpacePreset.NO_CONVERSION,
+                input_space=None,
+            )
 
             image = buf.get_pixels(oiio.FLOAT)
             if image is None or image.size == 0:

--- a/tests/test_ui_widgets.py
+++ b/tests/test_ui_widgets.py
@@ -1,11 +1,22 @@
 """Tests for shared UI widget helpers."""
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 
 from renderkit.core.config import BurnInConfig, BurnInElement
 from renderkit.processing.color_space import ColorSpacePreset
-from renderkit.ui.widgets import _prepare_buf_for_preview_display, _scaled_burnin_config_for_preview
+from renderkit.processing.frame_pipeline import (
+    FramePreparationOptions,
+    PreparedFrameBuffer,
+    prepare_frame_buffer,
+)
+from renderkit.ui.widgets import (
+    PreviewWorker,
+    _prepare_buf_for_preview_display,
+    _scaled_burnin_config_for_preview,
+)
 
 try:
     import OpenImageIO as oiio
@@ -79,6 +90,92 @@ def test_prepare_buf_for_preview_display_expands_data_channels(channels: int) ->
     np.testing.assert_allclose(result_pixels[:, :, 0], pixels[:, :, 0])
     np.testing.assert_allclose(result_pixels[:, :, 1], pixels[:, :, 0])
     np.testing.assert_allclose(result_pixels[:, :, 2], pixels[:, :, 0])
+
+
+def test_prepare_frame_buffer_expands_data_channels_without_color_conversion() -> None:
+    """Shared frame prep should keep data-channel buffers preview/render safe."""
+    if oiio is None:
+        pytest.skip("OpenImageIO not available")
+
+    pixels = np.array(
+        [
+            [[0.1, 0.8], [0.2, 0.7]],
+            [[0.3, 0.6], [0.4, 0.5]],
+        ],
+        dtype=np.float32,
+    )
+    spec = oiio.ImageSpec(2, 2, 2, oiio.FLOAT)
+    buf = oiio.ImageBuf(spec)
+    assert buf.set_pixels(oiio.ROI(), pixels)
+
+    class Reader:
+        def read_imagebuf(self, path, layer=None, layer_map=None):
+            return buf
+
+    class FailingColorConverter:
+        def convert_buf(self, buf, input_space=None):
+            raise AssertionError("data-channel buffers should not be color converted")
+
+    prepared = prepare_frame_buffer(
+        FramePreparationOptions(
+            frame_path=Path("render.0001.exr"),
+            frame_num=1,
+            output_width=2,
+            output_height=2,
+            source_width=2,
+            source_height=2,
+            scaler=object(),
+            input_space="rendering",
+            color_converter=FailingColorConverter(),
+            reader=Reader(),
+        )
+    )
+
+    result_spec = prepared.buf.spec()
+    assert result_spec.nchannels == 3
+    result_pixels = prepared.buf.get_pixels(oiio.FLOAT)
+    np.testing.assert_allclose(result_pixels[:, :, 0], pixels[:, :, 0])
+    np.testing.assert_allclose(result_pixels[:, :, 1], pixels[:, :, 0])
+    np.testing.assert_allclose(result_pixels[:, :, 2], pixels[:, :, 0])
+
+
+def test_preview_worker_delegates_imagebuf_processing(monkeypatch, qapp) -> None:
+    """Preview worker should keep shared processing separate from Qt image creation."""
+    if oiio is None:
+        pytest.skip("OpenImageIO not available")
+
+    spec = oiio.ImageSpec(1, 1, 3, oiio.FLOAT)
+    buf = oiio.ImageBuf(spec)
+    assert buf.set_pixels(oiio.ROI(), np.ones((1, 1, 3), dtype=np.float32))
+
+    calls = []
+
+    def fake_prepare_frame_buffer(options):
+        calls.append(options)
+        return PreparedFrameBuffer(buf=buf, applied_scale=0.5)
+
+    monkeypatch.setattr("renderkit.ui.widgets.prepare_frame_buffer", fake_prepare_frame_buffer)
+
+    emitted = []
+    worker = PreviewWorker(
+        file_path="render.0001.exr",
+        color_space=ColorSpacePreset.LINEAR_TO_SRGB,
+        input_space="rendering",
+        layer="beauty",
+        preview_scale=0.5,
+    )
+    worker.preview_ready.connect(emitted.append)
+
+    worker.run()
+
+    assert emitted
+    assert calls
+    call = calls[0]
+    assert call.frame_path == "render.0001.exr"
+    assert call.layer == "beauty"
+    assert call.input_space == "rendering"
+    assert call.output_scale == pytest.approx(0.5)
+    assert call.contact_sheet_config is None
 
 
 def test_no_wheel_combo_popup_tracks_hover(qtbot, qapp) -> None:


### PR DESCRIPTION
## Summary
- add a shared `processing.frame_pipeline` ImageBuf preparation path for read/contact sheet, color conversion, scaling, data-channel normalization, and burn-ins
- route `SequenceConverter._prepare_frame_buf` through the shared helper
- slim `PreviewWorker` so it delegates ImageBuf preparation and keeps only Qt display conversion/pixmap creation in UI code
- add tests for shared data-channel handling and preview worker delegation

## Root cause
Preview preparation duplicated production frame processing in `ui/widgets.py`, so changes to scaling, non-RGB handling, contact sheets, or burn-in ordering could drift away from render conversion behavior.

## Validation
- `uv --system-certs run ruff check`
- `uv --system-certs run ruff format --check`
- `uv --system-certs run --extra dev pytest` (153 passed, 9 skipped)

Closes #104