### PR TITLE
[codex] Extract main window helper modules

### DIFF
--- a/src/renderkit/ui/main_window_logic.py
+++ b/src/renderkit/ui/main_window_logic.py
@@ -4,15 +4,11 @@ from __future__ import annotations
 
 import logging
 import math
-from collections.abc import Callable
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 from renderkit import constants
 from renderkit.core.config import (
-    BurnInConfig,
-    BurnInElement,
     ContactSheetConfig,
     ConversionConfig,
     ConversionConfigBuilder,
@@ -31,6 +27,17 @@ from renderkit.processing.video_encoder import get_encoder_probe_result, select_
 from renderkit.ui.conversion_worker import ConversionWorker
 from renderkit.ui.file_info_worker import FileInfoWorker
 from renderkit.ui.icons import icon_manager
+from renderkit.ui.main_window_preview import build_burnin_config, build_preview_request
+from renderkit.ui.main_window_sequence import (
+    build_pattern_from_path,
+    derive_sequence_stem,
+    pattern_has_frame_token,
+)
+from renderkit.ui.main_window_settings import (
+    load_settings,
+    reset_settings,
+    save_settings,
+)
 from renderkit.ui.main_window_widgets import UiLogForwarder
 from renderkit.ui.qt_compat import (
     QApplication,
@@ -50,162 +57,6 @@ logger = logging.getLogger("renderkit.ui.main_window")
 RECENT_PATTERNS_LIMIT = 10
 RECENT_PATTERNS_KEY = "recent_patterns"
 RECENT_PATTERNS_CLEAR_LABEL = "Clear recent patterns"
-
-
-@dataclass(frozen=True)
-class _SettingSpec:
-    key: str
-    default: Any
-    value_type: type[Any]
-    getter: Callable[[Any], Any]
-    setter: Callable[[Any, Any], None]
-    is_available: Callable[[Any], bool] = lambda _: True
-
-
-SETTINGS_SCHEMA: tuple[_SettingSpec, ...] = (
-    _SettingSpec(
-        "fps",
-        24,
-        int,
-        lambda ui: ui.fps_spin.value(),
-        lambda ui, value: ui.fps_spin.setValue(value),
-    ),
-    _SettingSpec(
-        "keep_source_fps",
-        True,
-        bool,
-        lambda ui: ui.keep_source_fps_check.isChecked(),
-        lambda ui, value: ui.keep_source_fps_check.setChecked(value),
-    ),
-    _SettingSpec(
-        "keep_source_frame_range",
-        True,
-        bool,
-        lambda ui: ui.keep_source_frame_range_check.isChecked(),
-        lambda ui, value: ui.keep_source_frame_range_check.setChecked(value),
-    ),
-    _SettingSpec(
-        "width",
-        1920,
-        int,
-        lambda ui: ui.width_spin.value(),
-        lambda ui, value: ui.width_spin.setValue(value),
-    ),
-    _SettingSpec(
-        "height",
-        1080,
-        int,
-        lambda ui: ui.height_spin.value(),
-        lambda ui, value: ui.height_spin.setValue(value),
-    ),
-    _SettingSpec(
-        "codec_text",
-        "",
-        str,
-        lambda ui: ui.codec_combo.currentText(),
-        lambda ui, value: ui.codec_combo.setCurrentText(value),
-    ),
-    _SettingSpec(
-        "keep_resolution",
-        True,
-        bool,
-        lambda ui: ui.keep_resolution_check.isChecked(),
-        lambda ui, value: ui.keep_resolution_check.setChecked(value),
-    ),
-    _SettingSpec(
-        "aspect_linked",
-        True,
-        bool,
-        lambda ui: ui.aspect_link_btn.isChecked(),
-        lambda ui, value: ui.aspect_link_btn.setChecked(value),
-        lambda ui: hasattr(ui, "aspect_link_btn"),
-    ),
-    _SettingSpec(
-        "quality",
-        10,
-        int,
-        lambda ui: ui.quality_slider.value(),
-        lambda ui, value: ui.quality_slider.setValue(value),
-    ),
-    _SettingSpec(
-        "prefetch_workers",
-        2,
-        int,
-        lambda ui: ui.prefetch_workers_spin.value(),
-        lambda ui, value: ui.prefetch_workers_spin.setValue(value),
-        lambda ui: hasattr(ui, "prefetch_workers_spin"),
-    ),
-    _SettingSpec(
-        "burnin_enable",
-        True,
-        bool,
-        lambda ui: ui.burnin_enable_check.isChecked(),
-        lambda ui, value: ui.burnin_enable_check.setChecked(value),
-    ),
-    _SettingSpec(
-        "burnin_frame",
-        True,
-        bool,
-        lambda ui: ui.burnin_frame_check.isChecked(),
-        lambda ui, value: ui.burnin_frame_check.setChecked(value),
-    ),
-    _SettingSpec(
-        "burnin_layer",
-        True,
-        bool,
-        lambda ui: ui.burnin_layer_check.isChecked(),
-        lambda ui, value: ui.burnin_layer_check.setChecked(value),
-    ),
-    _SettingSpec(
-        "burnin_fps",
-        True,
-        bool,
-        lambda ui: ui.burnin_fps_check.isChecked(),
-        lambda ui, value: ui.burnin_fps_check.setChecked(value),
-    ),
-    _SettingSpec(
-        "burnin_font_size",
-        20,
-        int,
-        lambda ui: ui.burnin_font_size_spin.value(),
-        lambda ui, value: ui.burnin_font_size_spin.setValue(value),
-    ),
-    _SettingSpec(
-        "burnin_opacity",
-        30,
-        int,
-        lambda ui: ui.burnin_opacity_spin.value(),
-        lambda ui, value: ui.burnin_opacity_spin.setValue(value),
-    ),
-    _SettingSpec(
-        "cs_enable",
-        False,
-        bool,
-        lambda ui: ui.cs_enable_check.isChecked(),
-        lambda ui, value: ui.cs_enable_check.setChecked(value),
-    ),
-    _SettingSpec(
-        "cs_columns",
-        4,
-        int,
-        lambda ui: ui.cs_columns_spin.value(),
-        lambda ui, value: ui.cs_columns_spin.setValue(value),
-    ),
-    _SettingSpec(
-        "cs_padding",
-        4,
-        int,
-        lambda ui: ui.cs_padding_spin.value(),
-        lambda ui, value: ui.cs_padding_spin.setValue(value),
-    ),
-    _SettingSpec(
-        "preview_scale",
-        75,
-        int,
-        lambda ui: ui.preview_scale_spin.value(),
-        lambda ui, value: ui.preview_scale_spin.setValue(value),
-    ),
-)
 
 
 class MainWindowLogicMixin:
@@ -500,28 +351,7 @@ class MainWindowLogicMixin:
         if reply != QMessageBox.StandardButton.Yes:
             return
 
-        self.fps_spin.setValue(24)
-        self.keep_source_fps_check.setChecked(True)
-        self.keep_source_frame_range_check.setChecked(True)
-        self.width_spin.setValue(1920)
-        self.height_spin.setValue(1080)
-        self.codec_combo.setCurrentIndex(0)
-        self.keep_resolution_check.setChecked(True)
-        self.quality_slider.setValue(10)
-        if hasattr(self, "prefetch_workers_spin"):
-            self.prefetch_workers_spin.setValue(2)
-
-        self.burnin_enable_check.setChecked(True)
-        self.burnin_frame_check.setChecked(True)
-        self.burnin_layer_check.setChecked(True)
-        self.burnin_fps_check.setChecked(True)
-        self.burnin_font_size_spin.setValue(20)
-        self.burnin_opacity_spin.setValue(30)
-
-        self.cs_enable_check.setChecked(False)
-        self.cs_columns_spin.setValue(4)
-        self.cs_padding_spin.setValue(4)
-        self.preview_scale_spin.setValue(75)
+        reset_settings(self)
         if hasattr(self, "overwrite_check"):
             self.overwrite_check.setChecked(True)
 
@@ -743,91 +573,6 @@ class MainWindowLogicMixin:
         if controller:
             controller.set_sequence(sequence)
 
-    def _pattern_has_frame_token(self, filename: str) -> bool:
-        if "%" in filename:
-            percent_index = filename.find("%")
-            i = percent_index + 1
-            while i < len(filename) and filename[i].isdigit():
-                i += 1
-            if i < len(filename) and filename[i] == "d":
-                return True
-
-        if "$F" in filename:
-            return True
-
-        if "#" in filename:
-            return True
-
-        stem = Path(filename).stem
-        if not stem:
-            return False
-        i = len(stem) - 1
-        while i >= 0 and stem[i].isdigit():
-            i -= 1
-        return i < len(stem) - 1
-
-    def _extract_frame_number(self, path: Path) -> Optional[int]:
-        """Extract trailing frame number from a filename."""
-        stem = path.stem
-        if not stem:
-            return None
-        import re
-
-        match = re.search(r"(\d+)$", stem)
-        if not match:
-            return None
-        try:
-            return int(match.group(1))
-        except ValueError:
-            return None
-
-    def _build_burnin_elements(self, *, include_layer: bool) -> list[BurnInElement]:
-        if not self.burnin_enable_check.isChecked():
-            return []
-
-        burnin_elements = []
-        font_size = self.burnin_font_size_spin.value()
-        if self.burnin_frame_check.isChecked():
-            burnin_elements.append(
-                BurnInElement(
-                    text_template="Frame: {frame}",
-                    x=0,
-                    y=10,
-                    font_size=font_size,
-                    alignment="left",
-                )
-            )
-        if include_layer and self.burnin_layer_check.isChecked():
-            burnin_elements.append(
-                BurnInElement(
-                    text_template="Layer: {layer}",
-                    x=0,
-                    y=10,
-                    font_size=font_size,
-                    alignment="center",
-                )
-            )
-        if self.burnin_fps_check.isChecked():
-            burnin_elements.append(
-                BurnInElement(
-                    text_template="FPS: {fps:.2f}",
-                    x=0,
-                    y=10,
-                    font_size=font_size,
-                    alignment="right",
-                )
-            )
-        return burnin_elements
-
-    def _build_burnin_config(self, *, include_layer: bool) -> Optional[BurnInConfig]:
-        burnin_elements = self._build_burnin_elements(include_layer=include_layer)
-        if not burnin_elements:
-            return None
-        return BurnInConfig(
-            elements=burnin_elements,
-            background_opacity=self.burnin_opacity_spin.value(),
-        )
-
     def _validate_input_pattern(self, pattern: str) -> tuple[bool, str]:
         if not pattern:
             return False, "No pattern specified."
@@ -846,7 +591,7 @@ class MainWindowLogicMixin:
         if suffix not in constants.OIIO_SUPPORTED_EXTENSIONS:
             return False, f"Unsupported image extension: .{suffix}"
 
-        if not self._pattern_has_frame_token(filename):
+        if not pattern_has_frame_token(filename):
             return (
                 False,
                 "Pattern must include a frame token (e.g., %04d, ####, $F4) or frame number.",
@@ -890,84 +635,32 @@ class MainWindowLogicMixin:
             return
 
         preset, input_space = self._get_current_color_space_config()
-
-        # Determine if we are in Contact Sheet mode
-        cs_config = None
-        layer = self.layer_combo.currentText()
-
-        if self.cs_enable_check.isChecked() and not scrubbing:
-            # Build config from UI
-            layer_width = None
-            layer_height = None
-            if not self.keep_resolution_check.isChecked():
-                layer_width = self.width_spin.value()
-                layer_height = self.height_spin.value()
-
-            show_labels = (
-                self.burnin_enable_check.isChecked() and self.burnin_layer_check.isChecked()
-            )
-            cs_config = ContactSheetConfig(
-                columns=self.cs_columns_spin.value(),
-                thumbnail_width=None,
-                padding=self.cs_padding_spin.value(),
-                show_labels=show_labels,
-                font_size=self.burnin_font_size_spin.value(),
-                background_color=(0.1, 0.1, 0.1, 1.0),  # Dark background for preview
-                layer_width=layer_width,
-                layer_height=layer_height,
-            )
-            # Set layer to None to avoid "Layer not found" warnings when generator handles it
-            layer = None
-
-        burnin_config = None
-        burnin_metadata = None
-        if not scrubbing:
-            burnin_config = self._build_burnin_config(
-                include_layer=not self.cs_enable_check.isChecked()
-            )
-            if burnin_config is not None:
-                frame_number = self._extract_frame_number(sample_path)
-                burnin_metadata = {
-                    "frame": frame_number if frame_number is not None else 0,
-                    "file": sample_path.name,
-                    "fps": float(self.fps_spin.value()),
-                    "layer": layer or "RGBA",
-                    "colorspace": input_space or "Unknown",
-                }
-
-        self._last_preview_path = sample_path
-        preview_scale = self.preview_scale_spin.value() / 100.0
-        self.preview_widget.load_preview(
+        request = build_preview_request(
+            self,
             sample_path,
-            preset,
+            preset=preset,
             input_space=input_space,
-            layer=layer,
-            cs_config=cs_config,
-            burnin_config=burnin_config,
-            burnin_metadata=burnin_metadata,
-            preview_scale=preview_scale,
+            scrubbing=scrubbing,
         )
 
-        if cs_config:
+        self._last_preview_path = sample_path
+        self.preview_widget.load_preview(
+            request.sample_path,
+            request.preset,
+            input_space=request.input_space,
+            layer=request.layer,
+            cs_config=request.cs_config,
+            burnin_config=request.burnin_config,
+            burnin_metadata=request.burnin_metadata,
+            preview_scale=request.preview_scale,
+        )
+
+        if request.cs_config:
             logger.debug(f"Loading Contact Sheet preview: {sample_path.name}")
         elif scrubbing:
-            logger.debug(f"Loading scrub preview: {sample_path.name} (Layer: {layer})")
+            logger.debug(f"Loading scrub preview: {sample_path.name} (Layer: {request.layer})")
         else:
-            logger.debug(f"Loading preview: {sample_path.name} (Layer: {layer})")
-
-    def _derive_sequence_stem(self, pattern: str) -> str:
-        if not pattern:
-            return ""
-        name = Path(pattern).name
-        stem = Path(name).stem
-
-        import re
-
-        stem = re.sub(r"%\d*d", "", stem)
-        stem = re.sub(r"\$F\d*", "", stem)
-        stem = re.sub(r"#+", "", stem)
-        stem = re.sub(r"\d+$", "", stem)
-        return stem.rstrip("._- ").strip()
+            logger.debug(f"Loading preview: {sample_path.name} (Layer: {request.layer})")
 
     def _scale_thumbnail_pixmap(self, pixmap):
         if pixmap.isNull():
@@ -1013,9 +706,9 @@ class MainWindowLogicMixin:
             )
             return
 
-        sequence_stem = self._derive_sequence_stem(self.input_pattern_combo.currentText().strip())
+        sequence_stem = derive_sequence_stem(self.input_pattern_combo.currentText().strip())
         if not sequence_stem and self._last_preview_path:
-            sequence_stem = self._derive_sequence_stem(self._last_preview_path.name)
+            sequence_stem = derive_sequence_stem(self._last_preview_path.name)
         if not sequence_stem:
             sequence_stem = "sequence"
 
@@ -1171,7 +864,7 @@ class MainWindowLogicMixin:
         pattern_groups: dict[str, list[Path]] = {}
         order: list[str] = []
         for path in files:
-            pattern = self._build_pattern_from_path(path)
+            pattern = build_pattern_from_path(path)
             if not pattern:
                 continue
             if pattern not in pattern_groups:
@@ -1211,7 +904,7 @@ class MainWindowLogicMixin:
             self._apply_input_path(supported[0])
             return
 
-        patterns = [self._build_pattern_from_path(path) for path in supported]
+        patterns = [build_pattern_from_path(path) for path in supported]
         if all(patterns) and len(set(patterns)) == 1:
             self._set_input_pattern(patterns[0], supported[0].parent)
             return
@@ -1259,29 +952,6 @@ class MainWindowLogicMixin:
         suffix = path.suffix.lower().lstrip(".")
         return suffix in constants.OIIO_SUPPORTED_EXTENSIONS
 
-    def _build_pattern_from_path(self, path: Path) -> Optional[str]:
-        if not path or not path.is_file():
-            return None
-
-        name_part, ext = path.stem, path.suffix
-        if not name_part or not ext:
-            return None
-
-        import re
-
-        digit_matches = list(re.finditer(r"\d+", name_part))
-        if not digit_matches:
-            return None
-
-        last_match = digit_matches[-1]
-        frame_number = last_match.group(0)
-        padding = len(frame_number)
-        pattern_name = (
-            name_part[: last_match.start()] + f"%0{padding}d" + name_part[last_match.end() :]
-        )
-        pattern_filename = pattern_name + ext
-        return str(path.parent / pattern_filename)
-
     def _set_input_pattern(self, pattern: str, base_dir: Optional[Path] = None) -> None:
         if base_dir is not None:
             self.settings.setValue("last_input_dir", str(base_dir))
@@ -1290,7 +960,7 @@ class MainWindowLogicMixin:
 
     def _apply_input_path(self, path: Path) -> None:
         self.settings.setValue("last_input_dir", str(path.parent))
-        pattern = self._build_pattern_from_path(path)
+        pattern = build_pattern_from_path(path)
         if pattern:
             self._set_input_pattern(pattern, path.parent)
             return
@@ -1723,7 +1393,7 @@ class MainWindowLogicMixin:
         if cs_config is not None:
             config_builder.with_contact_sheet(True, cs_config)
 
-        burnin_config = self._build_burnin_config(include_layer=cs_config is None)
+        burnin_config = build_burnin_config(self, include_layer=cs_config is None)
         if burnin_config is not None:
             config_builder.with_burnin(burnin_config)
 
@@ -1980,9 +1650,7 @@ class MainWindowLogicMixin:
 
     def _save_settings(self) -> None:
         """Save current settings."""
-        for spec in SETTINGS_SCHEMA:
-            if spec.is_available(self):
-                self.settings.setValue(spec.key, spec.getter(self))
+        save_settings(self)
 
     def _on_progress_update(self, current: int, total: int) -> None:
         """Handle progress update from worker.
@@ -2004,11 +1672,7 @@ class MainWindowLogicMixin:
 
     def _load_settings(self) -> None:
         """Load saved settings."""
-        for spec in SETTINGS_SCHEMA:
-            if not spec.is_available(self):
-                continue
-            value = self.settings.value(spec.key, spec.default, type=spec.value_type)
-            spec.setter(self, value)
+        load_settings(self)
 
         if hasattr(self, "aspect_link_btn"):
             self._update_aspect_link_icon()

--- a/src/renderkit/ui/main_window_preview.py
+++ b/src/renderkit/ui/main_window_preview.py
@@ -1,0 +1,154 @@
+"""Preview request assembly for the RenderKit main window."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from renderkit.core.config import BurnInConfig, BurnInElement, ContactSheetConfig
+from renderkit.processing.color_space import ColorSpacePreset
+from renderkit.ui.main_window_sequence import extract_frame_number
+
+
+@dataclass(frozen=True)
+class PreviewRequest:
+    """All arguments needed to load one preview frame."""
+
+    sample_path: Path
+    preset: ColorSpacePreset
+    input_space: Optional[str]
+    layer: Optional[str]
+    cs_config: Optional[ContactSheetConfig]
+    burnin_config: Optional[BurnInConfig]
+    burnin_metadata: Optional[dict[str, Any]]
+    preview_scale: float
+
+
+def build_burnin_config(ui: Any, *, include_layer: bool) -> Optional[BurnInConfig]:
+    """Build burn-in settings from the current main-window UI state."""
+    if not ui.burnin_enable_check.isChecked():
+        return None
+
+    burnin_elements = []
+    font_size = ui.burnin_font_size_spin.value()
+    if ui.burnin_frame_check.isChecked():
+        burnin_elements.append(
+            BurnInElement(
+                text_template="Frame: {frame}",
+                x=0,
+                y=10,
+                font_size=font_size,
+                alignment="left",
+            )
+        )
+    if include_layer and ui.burnin_layer_check.isChecked():
+        burnin_elements.append(
+            BurnInElement(
+                text_template="Layer: {layer}",
+                x=0,
+                y=10,
+                font_size=font_size,
+                alignment="center",
+            )
+        )
+    if ui.burnin_fps_check.isChecked():
+        burnin_elements.append(
+            BurnInElement(
+                text_template="FPS: {fps:.2f}",
+                x=0,
+                y=10,
+                font_size=font_size,
+                alignment="right",
+            )
+        )
+
+    if not burnin_elements:
+        return None
+    return BurnInConfig(
+        elements=burnin_elements,
+        background_opacity=ui.burnin_opacity_spin.value(),
+    )
+
+
+def build_preview_contact_sheet_config(ui: Any, *, scrubbing: bool) -> Optional[ContactSheetConfig]:
+    """Build contact-sheet settings for a preview request."""
+    if not ui.cs_enable_check.isChecked() or scrubbing:
+        return None
+
+    layer_width = None
+    layer_height = None
+    if not ui.keep_resolution_check.isChecked():
+        layer_width = ui.width_spin.value()
+        layer_height = ui.height_spin.value()
+
+    show_labels = ui.burnin_enable_check.isChecked() and ui.burnin_layer_check.isChecked()
+    return ContactSheetConfig(
+        columns=ui.cs_columns_spin.value(),
+        thumbnail_width=None,
+        padding=ui.cs_padding_spin.value(),
+        show_labels=show_labels,
+        font_size=ui.burnin_font_size_spin.value(),
+        background_color=(0.1, 0.1, 0.1, 1.0),
+        layer_width=layer_width,
+        layer_height=layer_height,
+    )
+
+
+def build_burnin_metadata(
+    sample_path: Path,
+    *,
+    fps: float,
+    layer: Optional[str],
+    input_space: Optional[str],
+) -> dict[str, Any]:
+    """Build metadata used by preview burn-in rendering."""
+    frame_number = extract_frame_number(sample_path)
+    return {
+        "frame": frame_number if frame_number is not None else 0,
+        "file": sample_path.name,
+        "fps": fps,
+        "layer": layer or "RGBA",
+        "colorspace": input_space or "Unknown",
+    }
+
+
+def build_preview_request(
+    ui: Any,
+    sample_path: Path,
+    *,
+    preset: ColorSpacePreset,
+    input_space: Optional[str],
+    scrubbing: bool,
+) -> PreviewRequest:
+    """Build the full preview widget request from the current UI state."""
+    layer = ui.layer_combo.currentText()
+    cs_config = build_preview_contact_sheet_config(ui, scrubbing=scrubbing)
+    if cs_config is not None:
+        layer = None
+
+    burnin_config = None
+    burnin_metadata = None
+    if not scrubbing:
+        burnin_config = build_burnin_config(
+            ui,
+            include_layer=not ui.cs_enable_check.isChecked(),
+        )
+        if burnin_config is not None:
+            burnin_metadata = build_burnin_metadata(
+                sample_path,
+                fps=float(ui.fps_spin.value()),
+                layer=layer,
+                input_space=input_space,
+            )
+
+    return PreviewRequest(
+        sample_path=sample_path,
+        preset=preset,
+        input_space=input_space,
+        layer=layer,
+        cs_config=cs_config,
+        burnin_config=burnin_config,
+        burnin_metadata=burnin_metadata,
+        preview_scale=ui.preview_scale_spin.value() / 100.0,
+    )

--- a/src/renderkit/ui/main_window_sequence.py
+++ b/src/renderkit/ui/main_window_sequence.py
@@ -2,9 +2,67 @@
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 from typing import Optional
+
+
+def _trailing_digit_span(text: str) -> Optional[tuple[int, int]]:
+    end = len(text)
+    start = end
+    while start > 0 and text[start - 1].isdigit():
+        start -= 1
+    if start == end:
+        return None
+    return start, end
+
+
+def _last_digit_run_span(text: str) -> Optional[tuple[int, int]]:
+    end = len(text)
+    while end > 0 and not text[end - 1].isdigit():
+        end -= 1
+    if end == 0:
+        return None
+
+    start = end
+    while start > 0 and text[start - 1].isdigit():
+        start -= 1
+    return start, end
+
+
+def _remove_percent_frame_tokens(text: str) -> str:
+    result = []
+    index = 0
+    while index < len(text):
+        if text[index] != "%":
+            result.append(text[index])
+            index += 1
+            continue
+
+        token_end = index + 1
+        while token_end < len(text) and text[token_end].isdigit():
+            token_end += 1
+        if token_end < len(text) and text[token_end] == "d":
+            index = token_end + 1
+            continue
+
+        result.append(text[index])
+        index += 1
+    return "".join(result)
+
+
+def _remove_houdini_frame_tokens(text: str) -> str:
+    result = []
+    index = 0
+    while index < len(text):
+        if text.startswith("$F", index):
+            index += 2
+            while index < len(text) and text[index].isdigit():
+                index += 1
+            continue
+
+        result.append(text[index])
+        index += 1
+    return "".join(result)
 
 
 def pattern_has_frame_token(filename: str) -> bool:
@@ -38,11 +96,11 @@ def extract_frame_number(path: Path) -> Optional[int]:
     if not stem:
         return None
 
-    match = re.search(r"(\d+)$", stem)
-    if not match:
+    span = _trailing_digit_span(stem)
+    if span is None:
         return None
     try:
-        return int(match.group(1))
+        return int(stem[span[0] : span[1]])
     except ValueError:
         return None
 
@@ -54,10 +112,12 @@ def derive_sequence_stem(pattern: str) -> str:
     name = Path(pattern).name
     stem = Path(name).stem
 
-    stem = re.sub(r"%\d*d", "", stem)
-    stem = re.sub(r"\$F\d*", "", stem)
-    stem = re.sub(r"#+", "", stem)
-    stem = re.sub(r"\d+$", "", stem)
+    stem = _remove_percent_frame_tokens(stem)
+    stem = _remove_houdini_frame_tokens(stem)
+    stem = stem.replace("#", "")
+    span = _trailing_digit_span(stem)
+    if span is not None:
+        stem = stem[: span[0]]
     return stem.rstrip("._- ").strip()
 
 
@@ -70,13 +130,12 @@ def build_pattern_from_path(path: Path) -> Optional[str]:
     if not name_part or not ext:
         return None
 
-    digit_matches = list(re.finditer(r"\d+", name_part))
-    if not digit_matches:
+    span = _last_digit_run_span(name_part)
+    if span is None:
         return None
 
-    last_match = digit_matches[-1]
-    frame_number = last_match.group(0)
+    frame_number = name_part[span[0] : span[1]]
     padding = len(frame_number)
-    pattern_name = name_part[: last_match.start()] + f"%0{padding}d" + name_part[last_match.end() :]
+    pattern_name = name_part[: span[0]] + f"%0{padding}d" + name_part[span[1] :]
     pattern_filename = pattern_name + ext
     return str(path.parent / pattern_filename)

--- a/src/renderkit/ui/main_window_sequence.py
+++ b/src/renderkit/ui/main_window_sequence.py
@@ -1,0 +1,82 @@
+"""Path and pattern helpers used by the main-window sequence workflow."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+
+def pattern_has_frame_token(filename: str) -> bool:
+    """Return whether a filename already looks like a frame-sequence pattern."""
+    if "%" in filename:
+        percent_index = filename.find("%")
+        i = percent_index + 1
+        while i < len(filename) and filename[i].isdigit():
+            i += 1
+        if i < len(filename) and filename[i] == "d":
+            return True
+
+    if "$F" in filename:
+        return True
+
+    if "#" in filename:
+        return True
+
+    stem = Path(filename).stem
+    if not stem:
+        return False
+    i = len(stem) - 1
+    while i >= 0 and stem[i].isdigit():
+        i -= 1
+    return i < len(stem) - 1
+
+
+def extract_frame_number(path: Path) -> Optional[int]:
+    """Extract a trailing frame number from a filename."""
+    stem = path.stem
+    if not stem:
+        return None
+
+    match = re.search(r"(\d+)$", stem)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except ValueError:
+        return None
+
+
+def derive_sequence_stem(pattern: str) -> str:
+    """Return a clean stem for a frame-sequence pattern."""
+    if not pattern:
+        return ""
+    name = Path(pattern).name
+    stem = Path(name).stem
+
+    stem = re.sub(r"%\d*d", "", stem)
+    stem = re.sub(r"\$F\d*", "", stem)
+    stem = re.sub(r"#+", "", stem)
+    stem = re.sub(r"\d+$", "", stem)
+    return stem.rstrip("._- ").strip()
+
+
+def build_pattern_from_path(path: Path) -> Optional[str]:
+    """Convert a numbered file path into a printf-style sequence pattern."""
+    if not path or not path.is_file():
+        return None
+
+    name_part, ext = path.stem, path.suffix
+    if not name_part or not ext:
+        return None
+
+    digit_matches = list(re.finditer(r"\d+", name_part))
+    if not digit_matches:
+        return None
+
+    last_match = digit_matches[-1]
+    frame_number = last_match.group(0)
+    padding = len(frame_number)
+    pattern_name = name_part[: last_match.start()] + f"%0{padding}d" + name_part[last_match.end() :]
+    pattern_filename = pattern_name + ext
+    return str(path.parent / pattern_filename)

--- a/src/renderkit/ui/main_window_settings.py
+++ b/src/renderkit/ui/main_window_settings.py
@@ -1,0 +1,197 @@
+"""Settings persistence helpers for the RenderKit main window."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SettingSpec:
+    """Describe how one main-window setting is read, written, and restored."""
+
+    key: str
+    default: Any
+    value_type: type[Any]
+    getter: Callable[[Any], Any]
+    setter: Callable[[Any, Any], None]
+    is_available: Callable[[Any], bool] = lambda _: True
+    resetter: Callable[[Any], None] | None = None
+
+    def reset(self, ui: Any) -> None:
+        """Restore this setting to its default UI state."""
+        if self.resetter is not None:
+            self.resetter(ui)
+            return
+        self.setter(ui, self.default)
+
+
+SETTINGS_SCHEMA: tuple[SettingSpec, ...] = (
+    SettingSpec(
+        "fps",
+        24,
+        int,
+        lambda ui: ui.fps_spin.value(),
+        lambda ui, value: ui.fps_spin.setValue(value),
+    ),
+    SettingSpec(
+        "keep_source_fps",
+        True,
+        bool,
+        lambda ui: ui.keep_source_fps_check.isChecked(),
+        lambda ui, value: ui.keep_source_fps_check.setChecked(value),
+    ),
+    SettingSpec(
+        "keep_source_frame_range",
+        True,
+        bool,
+        lambda ui: ui.keep_source_frame_range_check.isChecked(),
+        lambda ui, value: ui.keep_source_frame_range_check.setChecked(value),
+    ),
+    SettingSpec(
+        "width",
+        1920,
+        int,
+        lambda ui: ui.width_spin.value(),
+        lambda ui, value: ui.width_spin.setValue(value),
+    ),
+    SettingSpec(
+        "height",
+        1080,
+        int,
+        lambda ui: ui.height_spin.value(),
+        lambda ui, value: ui.height_spin.setValue(value),
+    ),
+    SettingSpec(
+        "codec_text",
+        "",
+        str,
+        lambda ui: ui.codec_combo.currentText(),
+        lambda ui, value: ui.codec_combo.setCurrentText(value),
+        resetter=lambda ui: ui.codec_combo.setCurrentIndex(0),
+    ),
+    SettingSpec(
+        "keep_resolution",
+        True,
+        bool,
+        lambda ui: ui.keep_resolution_check.isChecked(),
+        lambda ui, value: ui.keep_resolution_check.setChecked(value),
+    ),
+    SettingSpec(
+        "aspect_linked",
+        True,
+        bool,
+        lambda ui: ui.aspect_link_btn.isChecked(),
+        lambda ui, value: ui.aspect_link_btn.setChecked(value),
+        lambda ui: hasattr(ui, "aspect_link_btn"),
+    ),
+    SettingSpec(
+        "quality",
+        10,
+        int,
+        lambda ui: ui.quality_slider.value(),
+        lambda ui, value: ui.quality_slider.setValue(value),
+    ),
+    SettingSpec(
+        "prefetch_workers",
+        2,
+        int,
+        lambda ui: ui.prefetch_workers_spin.value(),
+        lambda ui, value: ui.prefetch_workers_spin.setValue(value),
+        lambda ui: hasattr(ui, "prefetch_workers_spin"),
+    ),
+    SettingSpec(
+        "burnin_enable",
+        True,
+        bool,
+        lambda ui: ui.burnin_enable_check.isChecked(),
+        lambda ui, value: ui.burnin_enable_check.setChecked(value),
+    ),
+    SettingSpec(
+        "burnin_frame",
+        True,
+        bool,
+        lambda ui: ui.burnin_frame_check.isChecked(),
+        lambda ui, value: ui.burnin_frame_check.setChecked(value),
+    ),
+    SettingSpec(
+        "burnin_layer",
+        True,
+        bool,
+        lambda ui: ui.burnin_layer_check.isChecked(),
+        lambda ui, value: ui.burnin_layer_check.setChecked(value),
+    ),
+    SettingSpec(
+        "burnin_fps",
+        True,
+        bool,
+        lambda ui: ui.burnin_fps_check.isChecked(),
+        lambda ui, value: ui.burnin_fps_check.setChecked(value),
+    ),
+    SettingSpec(
+        "burnin_font_size",
+        20,
+        int,
+        lambda ui: ui.burnin_font_size_spin.value(),
+        lambda ui, value: ui.burnin_font_size_spin.setValue(value),
+    ),
+    SettingSpec(
+        "burnin_opacity",
+        30,
+        int,
+        lambda ui: ui.burnin_opacity_spin.value(),
+        lambda ui, value: ui.burnin_opacity_spin.setValue(value),
+    ),
+    SettingSpec(
+        "cs_enable",
+        False,
+        bool,
+        lambda ui: ui.cs_enable_check.isChecked(),
+        lambda ui, value: ui.cs_enable_check.setChecked(value),
+    ),
+    SettingSpec(
+        "cs_columns",
+        4,
+        int,
+        lambda ui: ui.cs_columns_spin.value(),
+        lambda ui, value: ui.cs_columns_spin.setValue(value),
+    ),
+    SettingSpec(
+        "cs_padding",
+        4,
+        int,
+        lambda ui: ui.cs_padding_spin.value(),
+        lambda ui, value: ui.cs_padding_spin.setValue(value),
+    ),
+    SettingSpec(
+        "preview_scale",
+        75,
+        int,
+        lambda ui: ui.preview_scale_spin.value(),
+        lambda ui, value: ui.preview_scale_spin.setValue(value),
+    ),
+)
+
+
+def save_settings(ui: Any) -> None:
+    """Persist all available main-window settings."""
+    for spec in SETTINGS_SCHEMA:
+        if spec.is_available(ui):
+            ui.settings.setValue(spec.key, spec.getter(ui))
+
+
+def load_settings(ui: Any) -> None:
+    """Restore all available main-window settings."""
+    for spec in SETTINGS_SCHEMA:
+        if not spec.is_available(ui):
+            continue
+        value = ui.settings.value(spec.key, spec.default, type=spec.value_type)
+        spec.setter(ui, value)
+
+
+def reset_settings(ui: Any) -> None:
+    """Reset all available main-window settings to their defaults."""
+    for spec in SETTINGS_SCHEMA:
+        if spec.is_available(ui):
+            spec.reset(ui)

--- a/tests/test_main_window_preview.py
+++ b/tests/test_main_window_preview.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from renderkit.processing.color_space import ColorSpacePreset
 from renderkit.ui.main_window_preview import build_burnin_config, build_preview_request
 
@@ -17,16 +19,18 @@ class _DummyValue:
 class _DummyCheck:
     def __init__(self, checked: bool) -> None:
         self._checked = checked
+        self.isChecked = self.is_checked
 
-    def isChecked(self) -> bool:
+    def is_checked(self) -> bool:
         return self._checked
 
 
 class _DummyCombo:
     def __init__(self, text: str) -> None:
         self._text = text
+        self.currentText = self.current_text
 
-    def currentText(self) -> str:
+    def current_text(self) -> str:
         return self._text
 
 
@@ -69,7 +73,7 @@ def test_build_preview_request_keeps_single_layer_preview_simple(tmp_path: Path)
     assert request.cs_config is None
     assert request.burnin_config is None
     assert request.burnin_metadata is None
-    assert request.preview_scale == 0.5
+    assert request.preview_scale == pytest.approx(0.5)
 
 
 def test_build_preview_request_uses_contact_sheet_config(tmp_path: Path) -> None:

--- a/tests/test_main_window_preview.py
+++ b/tests/test_main_window_preview.py
@@ -1,0 +1,151 @@
+"""Tests for main-window preview request assembly."""
+
+from pathlib import Path
+
+from renderkit.processing.color_space import ColorSpacePreset
+from renderkit.ui.main_window_preview import build_burnin_config, build_preview_request
+
+
+class _DummyValue:
+    def __init__(self, value) -> None:
+        self._value = value
+
+    def value(self):
+        return self._value
+
+
+class _DummyCheck:
+    def __init__(self, checked: bool) -> None:
+        self._checked = checked
+
+    def isChecked(self) -> bool:
+        return self._checked
+
+
+class _DummyCombo:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def currentText(self) -> str:
+        return self._text
+
+
+class _DummyWindow:
+    def __init__(self, *, contact_sheet: bool, burnin: bool, keep_resolution: bool = True) -> None:
+        self.preview_scale_spin = _DummyValue(50)
+        self.keep_resolution_check = _DummyCheck(keep_resolution)
+        self.width_spin = _DummyValue(1920)
+        self.height_spin = _DummyValue(1080)
+        self.cs_enable_check = _DummyCheck(contact_sheet)
+        self.cs_columns_spin = _DummyValue(4)
+        self.cs_padding_spin = _DummyValue(6)
+        self.layer_combo = _DummyCombo("beauty")
+        self.fps_spin = _DummyValue(24)
+        self.burnin_enable_check = _DummyCheck(burnin)
+        self.burnin_frame_check = _DummyCheck(True)
+        self.burnin_layer_check = _DummyCheck(True)
+        self.burnin_fps_check = _DummyCheck(True)
+        self.burnin_font_size_spin = _DummyValue(20)
+        self.burnin_opacity_spin = _DummyValue(30)
+
+
+def test_build_preview_request_keeps_single_layer_preview_simple(tmp_path: Path) -> None:
+    """Normal previews should preserve layer, color, and scale settings."""
+    sample_path = tmp_path / "render.0001.exr"
+    ui = _DummyWindow(contact_sheet=False, burnin=False)
+
+    request = build_preview_request(
+        ui,
+        sample_path,
+        preset=ColorSpacePreset.OCIO_CONVERSION,
+        input_space="Linear",
+        scrubbing=False,
+    )
+
+    assert request.sample_path == sample_path
+    assert request.preset == ColorSpacePreset.OCIO_CONVERSION
+    assert request.input_space == "Linear"
+    assert request.layer == "beauty"
+    assert request.cs_config is None
+    assert request.burnin_config is None
+    assert request.burnin_metadata is None
+    assert request.preview_scale == 0.5
+
+
+def test_build_preview_request_uses_contact_sheet_config(tmp_path: Path) -> None:
+    """Contact-sheet previews should delegate layer handling to the generator."""
+    sample_path = tmp_path / "render.0001.exr"
+    ui = _DummyWindow(contact_sheet=True, burnin=True, keep_resolution=False)
+
+    request = build_preview_request(
+        ui,
+        sample_path,
+        preset=ColorSpacePreset.OCIO_CONVERSION,
+        input_space="ACEScg",
+        scrubbing=False,
+    )
+
+    assert request.layer is None
+    assert request.cs_config is not None
+    assert request.cs_config.columns == 4
+    assert request.cs_config.padding == 6
+    assert request.cs_config.show_labels is True
+    assert request.cs_config.layer_width == 1920
+    assert request.cs_config.layer_height == 1080
+    assert request.burnin_metadata["layer"] == "RGBA"
+
+
+def test_build_preview_request_builds_burnin_metadata(tmp_path: Path) -> None:
+    """Burn-in previews should include frame and display metadata."""
+    sample_path = tmp_path / "render.0100.exr"
+    ui = _DummyWindow(contact_sheet=False, burnin=True)
+
+    request = build_preview_request(
+        ui,
+        sample_path,
+        preset=ColorSpacePreset.OCIO_CONVERSION,
+        input_space=None,
+        scrubbing=False,
+    )
+
+    assert request.burnin_config is not None
+    assert request.burnin_config.background_opacity == 30
+    templates = [element.text_template for element in request.burnin_config.elements]
+    assert templates == ["Frame: {frame}", "Layer: {layer}", "FPS: {fps:.2f}"]
+    assert request.burnin_metadata == {
+        "frame": 100,
+        "file": "render.0100.exr",
+        "fps": 24.0,
+        "layer": "beauty",
+        "colorspace": "Unknown",
+    }
+
+
+def test_build_preview_request_disables_expensive_options_while_scrubbing(tmp_path: Path) -> None:
+    """Timeline scrubbing should skip contact-sheet and burn-in preview work."""
+    sample_path = tmp_path / "render.0100.exr"
+    ui = _DummyWindow(contact_sheet=True, burnin=True)
+
+    request = build_preview_request(
+        ui,
+        sample_path,
+        preset=ColorSpacePreset.OCIO_CONVERSION,
+        input_space="Linear",
+        scrubbing=True,
+    )
+
+    assert request.layer == "beauty"
+    assert request.cs_config is None
+    assert request.burnin_config is None
+    assert request.burnin_metadata is None
+
+
+def test_build_burnin_config_can_exclude_layer_template() -> None:
+    """Contact-sheet conversions should be able to omit the per-layer burn-in."""
+    ui = _DummyWindow(contact_sheet=True, burnin=True)
+
+    config = build_burnin_config(ui, include_layer=False)
+
+    assert config is not None
+    templates = [element.text_template for element in config.elements]
+    assert templates == ["Frame: {frame}", "FPS: {fps:.2f}"]

--- a/tests/test_main_window_preview.py
+++ b/tests/test_main_window_preview.py
@@ -19,19 +19,27 @@ class _DummyValue:
 class _DummyCheck:
     def __init__(self, checked: bool) -> None:
         self._checked = checked
-        self.isChecked = self.is_checked
 
     def is_checked(self) -> bool:
         return self._checked
+
+    def __getattr__(self, name: str):
+        if name == "isChecked":
+            return self.is_checked
+        raise AttributeError(name)
 
 
 class _DummyCombo:
     def __init__(self, text: str) -> None:
         self._text = text
-        self.currentText = self.current_text
 
     def current_text(self) -> str:
         return self._text
+
+    def __getattr__(self, name: str):
+        if name == "currentText":
+            return self.current_text
+        raise AttributeError(name)
 
 
 class _DummyWindow:

--- a/tests/test_main_window_sequence.py
+++ b/tests/test_main_window_sequence.py
@@ -1,0 +1,52 @@
+"""Tests for main-window sequence path helpers."""
+
+from pathlib import Path
+
+from renderkit.ui.main_window_sequence import (
+    build_pattern_from_path,
+    derive_sequence_stem,
+    extract_frame_number,
+    pattern_has_frame_token,
+)
+
+
+def test_pattern_has_frame_token_recognizes_patterns_and_numbered_files() -> None:
+    """Existing pattern syntax and numbered filenames should be accepted."""
+    assert pattern_has_frame_token("render.%04d.exr") is True
+    assert pattern_has_frame_token("render.$F4.exr") is True
+    assert pattern_has_frame_token("render.####.exr") is True
+    assert pattern_has_frame_token("render.1001.exr") is True
+    assert pattern_has_frame_token("render.final.exr") is False
+
+
+def test_extract_frame_number_uses_trailing_digits() -> None:
+    """Only the terminal filename number should be treated as the frame."""
+    assert extract_frame_number(Path("shot.v003.1001.exr")) == 1001
+    assert extract_frame_number(Path("shot.v003.exr")) == 3
+    assert extract_frame_number(Path("shot.final.exr")) is None
+
+
+def test_derive_sequence_stem_removes_pattern_tokens() -> None:
+    """Pattern tokens should be stripped from generated thumbnail stems."""
+    assert derive_sequence_stem("C:/show/shot/render.%04d.exr") == "render"
+    assert derive_sequence_stem("render.$F4.exr") == "render"
+    assert derive_sequence_stem("render.####.exr") == "render"
+    assert derive_sequence_stem("render.1001.exr") == "render"
+
+
+def test_build_pattern_from_path_uses_last_number_group(tmp_path: Path) -> None:
+    """Numbered files should become printf-style patterns using the frame padding."""
+    source = tmp_path / "shot.v003.render.1001.exr"
+    source.write_text("data")
+
+    assert build_pattern_from_path(source) == str(tmp_path / "shot.v003.render.%04d.exr")
+
+
+def test_build_pattern_from_path_rejects_non_numbered_or_missing_files(tmp_path: Path) -> None:
+    """Files without frame numbers should not create a sequence pattern."""
+    missing = tmp_path / "shot.1001.exr"
+    unnumbered = tmp_path / "shot.final.exr"
+    unnumbered.write_text("data")
+
+    assert build_pattern_from_path(missing) is None
+    assert build_pattern_from_path(unnumbered) is None

--- a/tests/test_main_window_settings.py
+++ b/tests/test_main_window_settings.py
@@ -1,0 +1,132 @@
+"""Tests for main-window settings persistence helpers."""
+
+from renderkit.ui.main_window_settings import load_settings, reset_settings, save_settings
+
+
+class _Settings:
+    def __init__(self) -> None:
+        self.values = {}
+
+    def setValue(self, key, value) -> None:
+        self.values[key] = value
+
+    def value(self, key, default, type=None):
+        value = self.values.get(key, default)
+        if type is None:
+            return value
+        return type(value)
+
+
+class _ValueWidget:
+    def __init__(self, value) -> None:
+        self._value = value
+
+    def value(self):
+        return self._value
+
+    def setValue(self, value) -> None:
+        self._value = value
+
+
+class _CheckWidget:
+    def __init__(self, checked: bool) -> None:
+        self._checked = checked
+
+    def isChecked(self) -> bool:
+        return self._checked
+
+    def setChecked(self, checked: bool) -> None:
+        self._checked = checked
+
+
+class _ComboWidget:
+    def __init__(self, text: str) -> None:
+        self._text = text
+        self._index = 1
+
+    def currentText(self) -> str:
+        return self._text
+
+    def setCurrentText(self, text: str) -> None:
+        self._text = text
+
+    def setCurrentIndex(self, index: int) -> None:
+        self._index = index
+        if index == 0:
+            self._text = "H.264"
+
+    def currentIndex(self) -> int:
+        return self._index
+
+
+class _DummyWindow:
+    def __init__(self) -> None:
+        self.settings = _Settings()
+        self.fps_spin = _ValueWidget(48)
+        self.keep_source_fps_check = _CheckWidget(False)
+        self.keep_source_frame_range_check = _CheckWidget(False)
+        self.width_spin = _ValueWidget(2048)
+        self.height_spin = _ValueWidget(858)
+        self.codec_combo = _ComboWidget("H.265")
+        self.keep_resolution_check = _CheckWidget(False)
+        self.aspect_link_btn = _CheckWidget(False)
+        self.quality_slider = _ValueWidget(7)
+        self.prefetch_workers_spin = _ValueWidget(5)
+        self.burnin_enable_check = _CheckWidget(False)
+        self.burnin_frame_check = _CheckWidget(False)
+        self.burnin_layer_check = _CheckWidget(False)
+        self.burnin_fps_check = _CheckWidget(False)
+        self.burnin_font_size_spin = _ValueWidget(32)
+        self.burnin_opacity_spin = _ValueWidget(80)
+        self.cs_enable_check = _CheckWidget(True)
+        self.cs_columns_spin = _ValueWidget(3)
+        self.cs_padding_spin = _ValueWidget(9)
+        self.preview_scale_spin = _ValueWidget(50)
+
+
+def test_save_settings_persists_available_widget_values() -> None:
+    """Saved settings should use the UI's current values."""
+    window = _DummyWindow()
+
+    save_settings(window)
+
+    assert window.settings.values["fps"] == 48
+    assert window.settings.values["codec_text"] == "H.265"
+    assert window.settings.values["cs_enable"] is True
+    assert window.settings.values["preview_scale"] == 50
+
+
+def test_load_settings_restores_typed_values() -> None:
+    """Stored values should be restored through the setting schema."""
+    window = _DummyWindow()
+    window.settings.values.update(
+        {
+            "fps": "30",
+            "keep_resolution": "True",
+            "codec_text": "H.264",
+            "preview_scale": "25",
+        }
+    )
+
+    load_settings(window)
+
+    assert window.fps_spin.value() == 30
+    assert window.keep_resolution_check.isChecked() is True
+    assert window.codec_combo.currentText() == "H.264"
+    assert window.preview_scale_spin.value() == 25
+
+
+def test_reset_settings_restores_defaults_and_codec_index() -> None:
+    """Reset should centralize defaults without changing codec reset behavior."""
+    window = _DummyWindow()
+
+    reset_settings(window)
+
+    assert window.fps_spin.value() == 24
+    assert window.keep_source_fps_check.isChecked() is True
+    assert window.width_spin.value() == 1920
+    assert window.height_spin.value() == 1080
+    assert window.codec_combo.currentIndex() == 0
+    assert window.quality_slider.value() == 10
+    assert window.cs_enable_check.isChecked() is False
+    assert window.preview_scale_spin.value() == 75

--- a/tests/test_main_window_settings.py
+++ b/tests/test_main_window_settings.py
@@ -6,7 +6,6 @@ from renderkit.ui.main_window_settings import load_settings, reset_settings, sav
 class _Settings:
     def __init__(self) -> None:
         self.values = {}
-        self.setValue = self.set_value
 
     def set_value(self, key, value) -> None:
         self.values[key] = value
@@ -17,11 +16,15 @@ class _Settings:
             return value
         return type(value)
 
+    def __getattr__(self, name: str):
+        if name == "setValue":
+            return self.set_value
+        raise AttributeError(name)
+
 
 class _ValueWidget:
     def __init__(self, value) -> None:
         self._value = value
-        self.setValue = self.set_value
 
     def value(self):
         return self._value
@@ -29,12 +32,15 @@ class _ValueWidget:
     def set_value(self, value) -> None:
         self._value = value
 
+    def __getattr__(self, name: str):
+        if name == "setValue":
+            return self.set_value
+        raise AttributeError(name)
+
 
 class _CheckWidget:
     def __init__(self, checked: bool) -> None:
         self._checked = checked
-        self.isChecked = self.is_checked
-        self.setChecked = self.set_checked
 
     def is_checked(self) -> bool:
         return self._checked
@@ -42,15 +48,18 @@ class _CheckWidget:
     def set_checked(self, checked: bool) -> None:
         self._checked = checked
 
+    def __getattr__(self, name: str):
+        if name == "isChecked":
+            return self.is_checked
+        if name == "setChecked":
+            return self.set_checked
+        raise AttributeError(name)
+
 
 class _ComboWidget:
     def __init__(self, text: str) -> None:
         self._text = text
         self._index = 1
-        self.currentText = self.current_text
-        self.currentIndex = self.current_index
-        self.setCurrentText = self.set_current_text
-        self.setCurrentIndex = self.set_current_index
 
     def current_text(self) -> str:
         return self._text
@@ -65,6 +74,17 @@ class _ComboWidget:
 
     def current_index(self) -> int:
         return self._index
+
+    def __getattr__(self, name: str):
+        if name == "currentText":
+            return self.current_text
+        if name == "setCurrentText":
+            return self.set_current_text
+        if name == "setCurrentIndex":
+            return self.set_current_index
+        if name == "currentIndex":
+            return self.current_index
+        raise AttributeError(name)
 
 
 class _DummyWindow:

--- a/tests/test_main_window_settings.py
+++ b/tests/test_main_window_settings.py
@@ -6,8 +6,9 @@ from renderkit.ui.main_window_settings import load_settings, reset_settings, sav
 class _Settings:
     def __init__(self) -> None:
         self.values = {}
+        self.setValue = self.set_value
 
-    def setValue(self, key, value) -> None:
+    def set_value(self, key, value) -> None:
         self.values[key] = value
 
     def value(self, key, default, type=None):
@@ -20,22 +21,25 @@ class _Settings:
 class _ValueWidget:
     def __init__(self, value) -> None:
         self._value = value
+        self.setValue = self.set_value
 
     def value(self):
         return self._value
 
-    def setValue(self, value) -> None:
+    def set_value(self, value) -> None:
         self._value = value
 
 
 class _CheckWidget:
     def __init__(self, checked: bool) -> None:
         self._checked = checked
+        self.isChecked = self.is_checked
+        self.setChecked = self.set_checked
 
-    def isChecked(self) -> bool:
+    def is_checked(self) -> bool:
         return self._checked
 
-    def setChecked(self, checked: bool) -> None:
+    def set_checked(self, checked: bool) -> None:
         self._checked = checked
 
 
@@ -43,19 +47,23 @@ class _ComboWidget:
     def __init__(self, text: str) -> None:
         self._text = text
         self._index = 1
+        self.currentText = self.current_text
+        self.currentIndex = self.current_index
+        self.setCurrentText = self.set_current_text
+        self.setCurrentIndex = self.set_current_index
 
-    def currentText(self) -> str:
+    def current_text(self) -> str:
         return self._text
 
-    def setCurrentText(self, text: str) -> None:
+    def set_current_text(self, text: str) -> None:
         self._text = text
 
-    def setCurrentIndex(self, index: int) -> None:
+    def set_current_index(self, index: int) -> None:
         self._index = index
         if index == 0:
             self._text = "H.264"
 
-    def currentIndex(self) -> int:
+    def current_index(self) -> int:
         return self._index
 
 


### PR DESCRIPTION
## Summary

- Extract main-window settings persistence/default handling into `main_window_settings.py`
- Extract sequence filename/path helpers into `main_window_sequence.py`
- Extract preview request assembly, contact-sheet preview setup, and preview burn-in metadata into `main_window_preview.py`
- Add focused tests for the new helper modules while preserving existing main-window behavior

## Why

`main_window_logic.py` had grown into a broad mixin that owned settings, sequence path parsing, preview assembly, conversion setup, and UI state transitions. This PR starts reducing that surface area with low-risk, testable helper modules so later UI bug fixes are easier to reason about.

## Validation

- `uv --system-certs run ruff check src/renderkit/ui/main_window_logic.py src/renderkit/ui/main_window_preview.py src/renderkit/ui/main_window_sequence.py src/renderkit/ui/main_window_settings.py tests/test_main_window_preview.py tests/test_main_window_sequence.py tests/test_main_window_settings.py`
- `uv --system-certs run pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal code architecture to improve maintainability and modularity.

* **Tests**
  * Added comprehensive unit tests for refactored preview handling, settings persistence, and sequence pattern detection components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->