### PR TITLE
Reinforce QImage buffer safety and memory management

### DIFF
--- a/src/renderkit/ui/preview_image.py
+++ b/src/renderkit/ui/preview_image.py
@@ -51,11 +51,27 @@ def imagebuf_to_preview_image(buf: oiio.ImageBuf) -> PreviewImageData:
 
 
 def preview_image_to_qimage(data: PreviewImageData) -> QImage:
-    """Create a QImage from preview image data."""
+    """Create a QImage from preview image data.
+
+    This function performs safety checks and returns a deep copy of the image.
+    Crucially, it checks that the array is C-contiguous (copying if necessary to
+    avoid garbled textures or segfaults) and that the dtype is uint8 (preventing
+    memory footprint/row stride mismatch corruption).
+
+    Finally, it returns a deep copy of the QImage to prevent a use-after-free bug
+    when the Python PreviewImageData goes out of scope and gets garbage collected.
+    """
+    if data.pixels.dtype != np.uint8:
+        raise ValueError(f"Preview image pixels must be uint8, but got dtype: {data.pixels.dtype}")
+
+    pixels = data.pixels
+    if not pixels.flags.c_contiguous:
+        pixels = np.ascontiguousarray(pixels)
+
     q_format = _qimage_format(data.channels)
     bytes_per_line = data.width * data.channels
     image = QImage(
-        data.pixels.data,
+        pixels.data,
         data.width,
         data.height,
         bytes_per_line,

--- a/tests/test_ui_widgets.py
+++ b/tests/test_ui_widgets.py
@@ -16,6 +16,7 @@ from renderkit.ui.preview_image import (
     PreviewImageData,
     imagebuf_to_preview_image,
     preview_image_to_pixmap,
+    preview_image_to_qimage,
 )
 from renderkit.ui.qt_compat import QPixmap
 from renderkit.ui.widgets import (
@@ -190,6 +191,51 @@ def test_preview_image_to_pixmap_returns_pixmap(qapp) -> None:
 
     assert isinstance(pixmap, QPixmap)
     assert not pixmap.isNull()
+
+
+def test_preview_image_to_qimage_rejects_non_uint8_dtype() -> None:
+    """Reject pixels with non-uint8 dtypes to prevent memory layout corruption."""
+    data = PreviewImageData(
+        pixels=np.full((2, 2, 3), 1.0, dtype=np.float32),
+        width=2,
+        height=2,
+        channels=3,
+    )
+    with pytest.raises(ValueError, match="Preview image pixels must be uint8"):
+        preview_image_to_qimage(data)
+
+
+def test_preview_image_to_qimage_handles_non_contiguous_array(qapp) -> None:
+    """Automatically convert non-contiguous NumPy arrays to C-contiguous for QImage safety."""
+    # 1. Fortran-contiguous array
+    f_pixels = np.asfortranarray(np.full((2, 2, 3), 128, dtype=np.uint8))
+    assert not f_pixels.flags.c_contiguous
+
+    data_f = PreviewImageData(
+        pixels=f_pixels,
+        width=2,
+        height=2,
+        channels=3,
+    )
+    qimage_f = preview_image_to_qimage(data_f)
+    assert qimage_f.width() == 2
+    assert qimage_f.height() == 2
+
+    # 2. Sliced/strided array view
+    large_pixels = np.zeros((4, 4, 3), dtype=np.uint8)
+    large_pixels[::2, ::2] = 255
+    sliced_pixels = large_pixels[::2, ::2]
+    assert not sliced_pixels.flags.c_contiguous
+
+    data_sliced = PreviewImageData(
+        pixels=sliced_pixels,
+        width=2,
+        height=2,
+        channels=3,
+    )
+    qimage_sliced = preview_image_to_qimage(data_sliced)
+    assert qimage_sliced.width() == 2
+    assert qimage_sliced.height() == 2
 
 
 def test_prepare_frame_buffer_expands_data_channels_without_color_conversion() -> None:


### PR DESCRIPTION
Reinforces buffer safety when marshaling PreviewImageData to QImage in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced image preview robustness with stricter validation of input image data formats and memory layouts. The function now provides clearer error messages for incompatible image data.

* **Tests**
  * Added test coverage for image data validation and memory layout handling in preview functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->