### PR TITLE
[codex] Refactor duplicated render helpers

### DIFF
--- a/src/renderkit/cli/main.py
+++ b/src/renderkit/cli/main.py
@@ -32,6 +32,7 @@ from renderkit.core.sequence_replacement import (
 from renderkit.exceptions import RenderKitError
 from renderkit.io.image_reader import ImageReaderFactory
 from renderkit.io.oiio_cache import get_shared_image_cache
+from renderkit.io.oiio_utils import require_oiio
 from renderkit.logging_utils import setup_logging
 from renderkit.processing.scaler import ImageScaler
 
@@ -85,10 +86,7 @@ def _write_sequence_contact_sheet(
     end_frame: Optional[int],
 ) -> None:
     """Write a still contact sheet made from frames in a sequence."""
-    try:
-        import OpenImageIO as oiio
-    except ImportError as exc:
-        raise RuntimeError("OpenImageIO library not available.") from exc
+    oiio = require_oiio()
 
     sequence = SequenceDetector.detect_sequence(input_pattern)
     frame_numbers = sequence.frame_numbers

--- a/src/renderkit/core/batch.py
+++ b/src/renderkit/core/batch.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from renderkit.core.sequence_names import split_numbered_frame_name
+
 
 @dataclass(frozen=True)
 class BatchSequence:
@@ -69,7 +71,7 @@ def discover_frame_sequences(root: Path, extension: str) -> list[BatchSequence]:
         if not frame_path.is_file() or frame_path.suffix.lower() != normalized_ext:
             continue
 
-        parsed_name = _split_frame_name(frame_path)
+        parsed_name = split_numbered_frame_name(frame_path)
         if parsed_name is None:
             continue
 
@@ -150,19 +152,6 @@ def _normalize_extension(extension: str) -> str:
     if not ext:
         raise ValueError("Extension cannot be empty")
     return ext if ext.startswith(".") else f".{ext}"
-
-
-def _split_frame_name(frame_path: Path) -> Optional[tuple[str, str, str]]:
-    suffix = frame_path.suffix
-    stem = frame_path.name[: -len(suffix)]
-    frame_start = len(stem)
-    while frame_start > 0 and stem[frame_start - 1].isdigit():
-        frame_start -= 1
-
-    if frame_start == len(stem):
-        return None
-
-    return stem[:frame_start], stem[frame_start:], suffix
 
 
 def _safe_filename_part(value: str) -> str:

--- a/src/renderkit/core/sequence_names.py
+++ b/src/renderkit/core/sequence_names.py
@@ -1,0 +1,46 @@
+"""Helpers for parsing numbered frame sequence names."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+
+def split_numbered_frame_name(
+    path_or_name: Path | str,
+    *,
+    required_extension: Optional[str] = None,
+) -> Optional[tuple[str, str, str]]:
+    """Split a numbered frame name into prefix, frame text, and suffix.
+
+    Args:
+        path_or_name: Path or filename with trailing frame digits before the extension.
+        required_extension: Optional extension filter, with or without a leading dot.
+
+    Returns:
+        Tuple of ``(prefix, frame_text, suffix)`` when a frame number is present,
+        otherwise ``None``.
+    """
+    path = Path(path_or_name)
+    suffix = path.suffix
+    if required_extension is not None and suffix.lower() != _normalize_extension(
+        required_extension
+    ):
+        return None
+
+    stem = path.stem
+    frame_start = len(stem)
+    while frame_start > 0 and stem[frame_start - 1].isdigit():
+        frame_start -= 1
+
+    if frame_start == len(stem):
+        return None
+
+    return stem[:frame_start], stem[frame_start:], suffix
+
+
+def _normalize_extension(extension: str) -> str:
+    normalized = extension.strip().lower()
+    if not normalized:
+        raise ValueError("Extension cannot be empty")
+    return normalized if normalized.startswith(".") else f".{normalized}"

--- a/src/renderkit/core/sequence_replacement.py
+++ b/src/renderkit/core/sequence_replacement.py
@@ -15,6 +15,7 @@ from typing import Optional
 from renderkit.core.batch import BatchSequence, build_safe_output_path
 from renderkit.core.ffmpeg_utils import get_ffprobe_exe, popen_kwargs
 from renderkit.core.sequence import FrameSequence, SequenceDetector
+from renderkit.core.sequence_names import split_numbered_frame_name
 from renderkit.exceptions import SequenceReplacementError
 
 Mp4Verifier = Callable[[Path], None]
@@ -237,7 +238,7 @@ def find_exr_sequences(root: Path) -> list[str]:
     for file_path in root.rglob("*.exr"):
         if not file_path.is_file():
             continue
-        numbered_name = _split_numbered_exr_name(file_path.name)
+        numbered_name = split_numbered_frame_name(file_path.name, required_extension=".exr")
         if numbered_name is None:
             continue
         prefix, frame, suffix = numbered_name
@@ -288,22 +289,6 @@ def _existing_sequence_frames(sequence: FrameSequence) -> list[Path]:
         for frame_number in sequence.frame_numbers
         if (path := sequence.get_file_path(frame_number)).is_file()
     ]
-
-
-def _split_numbered_exr_name(filename: str) -> Optional[tuple[str, str, str]]:
-    path = Path(filename)
-    if path.suffix.lower() != ".exr":
-        return None
-
-    stem = path.stem
-    frame_start = len(stem)
-    while frame_start > 0 and stem[frame_start - 1].isdigit():
-        frame_start -= 1
-
-    if frame_start == len(stem):
-        return None
-
-    return stem[:frame_start], stem[frame_start:], path.suffix
 
 
 def _sum_existing_sizes(paths: list[Path]) -> int:

--- a/src/renderkit/io/image_reader.py
+++ b/src/renderkit/io/image_reader.py
@@ -12,6 +12,7 @@ from renderkit.exceptions import ImageReadError
 from renderkit.io.file_info import FileInfo
 from renderkit.io.file_utils import FileUtils
 from renderkit.io.oiio_cache import get_shared_image_cache
+from renderkit.io.oiio_utils import ensure_float_imagebuf, require_oiio
 
 logger = logging.getLogger(__name__)
 
@@ -221,10 +222,7 @@ class OIIOReader(ImageReader):
             logger.debug(f"Using cached file info for {path}")
             return self._file_info_cache[cache_key]
 
-        try:
-            import OpenImageIO as oiio
-        except ImportError as e:
-            raise ImageReadError("OpenImageIO library not available.") from e
+        oiio = require_oiio(ImageReadError)
 
         if not path.exists():
             raise ImageReadError(f"File does not exist: {path}")
@@ -301,10 +299,7 @@ class OIIOReader(ImageReader):
         if cached is not None:
             return cached
 
-        try:
-            import OpenImageIO as oiio
-        except ImportError as e:
-            raise ImageReadError("OpenImageIO library not available.") from e
+        oiio = require_oiio(ImageReadError)
 
         if not path.exists():
             raise ImageReadError(f"File does not exist: {path}")
@@ -354,10 +349,7 @@ class OIIOReader(ImageReader):
         layer_map: Optional[dict[str, LayerMapEntry]] = None,
     ):
         """Read an image using OIIO ImageBuf and return the ImageBuf."""
-        try:
-            import OpenImageIO as oiio
-        except ImportError as e:
-            raise ImageReadError("OpenImageIO library not available.") from e
+        oiio = require_oiio(ImageReadError)
 
         if not path.exists():
             raise ImageReadError(f"File does not exist: {path}")
@@ -383,21 +375,12 @@ class OIIOReader(ImageReader):
                 path,
             )
 
-            # Ensure float32 for downstream processing
-            spec = buf.spec()
-            if spec.format != oiio.FLOAT:
-                float_spec = oiio.ImageSpec(
-                    spec.width,
-                    spec.height,
-                    spec.nchannels,
-                    oiio.FLOAT,
-                )
-                float_buf = oiio.ImageBuf(float_spec)
-                if not oiio.ImageBufAlgo.copy(float_buf, buf):
-                    raise ImageReadError(f"Failed to convert {path} to float32: {buf.geterror()}")
-                buf = float_buf
-
-            return buf
+            return ensure_float_imagebuf(
+                oiio,
+                buf,
+                error_type=ImageReadError,
+                error_message=f"Failed to convert {path} to float32",
+            )
 
         except ImageReadError:
             raise
@@ -490,10 +473,7 @@ class OIIOReader(ImageReader):
 
     def read_subimagebuf(self, path: Path, subimage_index: int):
         """Read a specific subimage as an OIIO ImageBuf."""
-        try:
-            import OpenImageIO as oiio
-        except ImportError as e:
-            raise ImageReadError("OpenImageIO library not available.") from e
+        oiio = require_oiio(ImageReadError)
 
         if not path.exists():
             raise ImageReadError(f"File does not exist: {path}")
@@ -530,20 +510,12 @@ class OIIOReader(ImageReader):
                     f"OIIO failed to read {path} (part {subimage_index}): {buf.geterror()}"
                 )
 
-            spec = buf.spec()
-            if spec.format != oiio.FLOAT:
-                float_spec = oiio.ImageSpec(
-                    spec.width,
-                    spec.height,
-                    spec.nchannels,
-                    oiio.FLOAT,
-                )
-                float_buf = oiio.ImageBuf(float_spec)
-                if not oiio.ImageBufAlgo.copy(float_buf, buf):
-                    raise ImageReadError(f"Failed to convert {path} to float32: {buf.geterror()}")
-                buf = float_buf
-
-            return buf
+            return ensure_float_imagebuf(
+                oiio,
+                buf,
+                error_type=ImageReadError,
+                error_message=f"Failed to convert {path} to float32",
+            )
 
         except ImageReadError:
             raise

--- a/src/renderkit/io/oiio_utils.py
+++ b/src/renderkit/io/oiio_utils.py
@@ -1,0 +1,37 @@
+"""Shared OpenImageIO import and buffer helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def require_oiio(
+    error_type: type[Exception] = RuntimeError,
+    message: str = "OpenImageIO library not available.",
+) -> Any:
+    """Import OpenImageIO or raise the caller's domain error."""
+    try:
+        import OpenImageIO as oiio
+    except ImportError as exc:
+        raise error_type(message) from exc
+    return oiio
+
+
+def ensure_float_imagebuf(
+    oiio: Any,
+    buf: Any,
+    *,
+    error_type: type[Exception] = RuntimeError,
+    error_message: str = "OIIO copy to float failed",
+) -> Any:
+    """Return ``buf`` as an OIIO FLOAT ImageBuf."""
+    spec = buf.spec()
+    if spec.format == oiio.FLOAT:
+        return buf
+
+    float_spec = oiio.ImageSpec(spec.width, spec.height, spec.nchannels, oiio.FLOAT)
+    float_buf = oiio.ImageBuf(float_spec)
+    if not oiio.ImageBufAlgo.copy(float_buf, buf):
+        details = oiio.geterror() or buf.geterror()
+        raise error_type(f"{error_message}: {details}")
+    return float_buf

--- a/src/renderkit/processing/burnin.py
+++ b/src/renderkit/processing/burnin.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Any
 
+from renderkit.io.oiio_utils import require_oiio
+
 logger = logging.getLogger(__name__)
 
 
@@ -9,12 +11,7 @@ class BurnInProcessor:
 
     def __init__(self) -> None:
         """Initialize the processor."""
-        try:
-            import OpenImageIO as oiio
-
-            self.oiio = oiio
-        except ImportError as e:
-            raise RuntimeError("OpenImageIO library not available.") from e
+        self.oiio = require_oiio()
 
     def apply_burnins(
         self,

--- a/src/renderkit/processing/color_space.py
+++ b/src/renderkit/processing/color_space.py
@@ -9,6 +9,7 @@ from typing import Any, Optional, Protocol
 
 from renderkit import constants
 from renderkit.exceptions import ColorSpaceError
+from renderkit.io.oiio_utils import require_oiio
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,11 @@ _OIIO_REC709_CANDIDATES = [
 ]
 _OIIO_COLOR_SPACE_CACHE: Optional[dict[str, str]] = None
 _BUNDLED_OCIO_CONFIG_CACHE: Optional[Path] = None
+_OIIO_COLOR_CONVERSION_ERROR = "OpenImageIO not available for color conversion."
+
+
+def _require_oiio_for_color_conversion():
+    return require_oiio(ColorSpaceError, _OIIO_COLOR_CONVERSION_ERROR)
 
 
 def get_bundled_ocio_config_path() -> Path:
@@ -515,10 +521,7 @@ class OCIOColorSpaceStrategy:
         if not input_space:
             raise ColorSpaceError("OCIO input color space is required.")
 
-        try:
-            import OpenImageIO as oiio
-        except ImportError as err:
-            raise ColorSpaceError("OpenImageIO not available for color conversion.") from err
+        oiio = _require_oiio_for_color_conversion()
 
         requested_input_space = input_space
         resolved_input_space: Optional[str] = input_space
@@ -552,10 +555,7 @@ class LinearToSRGBStrategy:
     """Strategy for converting linear to sRGB color space."""
 
     def convert_buf(self, buf: Any, input_space: Optional[str] = None):
-        try:
-            import OpenImageIO as oiio
-        except ImportError as err:
-            raise ColorSpaceError("OpenImageIO not available for color conversion.") from err
+        oiio = _require_oiio_for_color_conversion()
 
         tone_mapped = _oiio_tone_map_reinhard(oiio, buf)
         oiio_result = _oiio_colorconvert_buf(
@@ -571,10 +571,7 @@ class LinearToRec709Strategy:
     """Strategy for converting linear to Rec.709 color space."""
 
     def convert_buf(self, buf: Any, input_space: Optional[str] = None):
-        try:
-            import OpenImageIO as oiio
-        except ImportError as err:
-            raise ColorSpaceError("OpenImageIO not available for color conversion.") from err
+        oiio = _require_oiio_for_color_conversion()
 
         tone_mapped = _oiio_tone_map_reinhard(oiio, buf)
         oiio_result = _oiio_colorconvert_buf(
@@ -590,10 +587,7 @@ class SRGBToLinearStrategy:
     """Strategy for converting sRGB to linear color space."""
 
     def convert_buf(self, buf: Any, input_space: Optional[str] = None):
-        try:
-            import OpenImageIO as oiio
-        except ImportError as err:
-            raise ColorSpaceError("OpenImageIO not available for color conversion.") from err
+        oiio = _require_oiio_for_color_conversion()
 
         srgb = _oiio_clamp_buf(oiio, buf, 0.0, 1.0)
         return _oiio_colorconvert_buf(
@@ -608,10 +602,7 @@ class NoConversionStrategy:
     """Strategy for no color space conversion (passthrough)."""
 
     def convert_buf(self, buf: Any, input_space: Optional[str] = None):
-        try:
-            import OpenImageIO as oiio
-        except ImportError as err:
-            raise ColorSpaceError("OpenImageIO not available for color conversion.") from err
+        oiio = _require_oiio_for_color_conversion()
         return _ensure_float_buf(oiio, buf)
 
 

--- a/src/renderkit/processing/pixels.py
+++ b/src/renderkit/processing/pixels.py
@@ -1,0 +1,12 @@
+"""Pixel array conversion helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def float_pixels_to_uint8(pixels: np.ndarray) -> np.ndarray:
+    """Clamp float-like pixels to display-range uint8."""
+    pixels_f32 = pixels.astype(np.float32, copy=False)
+    clipped = np.clip(pixels_f32, 0.0, 1.0)
+    return (clipped * np.float32(255.0)).astype(np.uint8)

--- a/src/renderkit/processing/scaler.py
+++ b/src/renderkit/processing/scaler.py
@@ -1,10 +1,11 @@
 """Image scaling utilities using OpenImageIO (OIIO)."""
 
+from renderkit.io.oiio_utils import ensure_float_imagebuf, require_oiio
+
 
 class ImageScaler:
     """Utility class for image scaling using OpenImageIO."""
 
-    @staticmethod
     @staticmethod
     def scale_buf(
         buf,
@@ -13,19 +14,10 @@ class ImageScaler:
         filter_name: str = "lanczos3",
     ):
         """Scale an OIIO ImageBuf without converting to NumPy."""
-        try:
-            import OpenImageIO as oiio
-        except ImportError as e:
-            raise RuntimeError("OpenImageIO library not available.") from e
+        oiio = require_oiio()
 
         spec = buf.spec()
-        src_buf = buf
-        if spec.format != oiio.FLOAT:
-            float_spec = oiio.ImageSpec(spec.width, spec.height, spec.nchannels, oiio.FLOAT)
-            float_buf = oiio.ImageBuf(float_spec)
-            if not oiio.ImageBufAlgo.copy(float_buf, buf):
-                raise RuntimeError(f"OIIO copy to float failed: {oiio.geterror()}")
-            src_buf = float_buf
+        src_buf = ensure_float_imagebuf(oiio, buf)
 
         dst_buf = oiio.ImageBuf(oiio.ImageSpec(width, height, spec.nchannels, oiio.FLOAT))
         if not oiio.ImageBufAlgo.resize(dst_buf, src_buf, filtername=filter_name):

--- a/src/renderkit/processing/video_encoder.py
+++ b/src/renderkit/processing/video_encoder.py
@@ -15,6 +15,7 @@ import OpenImageIO as oiio
 
 from renderkit.core.ffmpeg_utils import get_ffmpeg_exe, popen_kwargs
 from renderkit.exceptions import ConfigurationError, VideoEncodingError
+from renderkit.processing.pixels import float_pixels_to_uint8
 from renderkit.processing.scaler import ImageScaler
 
 logger = logging.getLogger(__name__)
@@ -476,9 +477,7 @@ class VideoEncoder:
         else:
             frame = pixels
 
-        frame_f32 = frame.astype(np.float32, copy=False)
-        frame = np.clip(frame_f32, 0.0, 1.0)
-        frame = (frame * np.float32(255.0)).astype(np.uint8)
+        frame = float_pixels_to_uint8(frame)
 
         # FFmpeg rawvideo expects RGB (standard)
         # If RGBA, drop alpha channel

--- a/src/renderkit/ui/collapsible_group.py
+++ b/src/renderkit/ui/collapsible_group.py
@@ -4,10 +4,12 @@ from renderkit.ui.qt_compat import (
     QFrame,
     QHBoxLayout,
     QLabel,
-    Qt,
     QVBoxLayout,
     QWidget,
+    qt_enum,
 )
+
+_QT_POINTING_HAND_CURSOR = qt_enum("CursorShape", "PointingHandCursor")
 
 
 class CollapsibleGroupBox(QWidget):
@@ -35,7 +37,7 @@ class CollapsibleGroupBox(QWidget):
         # Header
         self.header = QFrame()
         self.header.setObjectName("CollapsibleHeader")
-        self.header.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.header.setCursor(_QT_POINTING_HAND_CURSOR)
         header_layout = QHBoxLayout(self.header)
         header_layout.setContentsMargins(12, 8, 12, 8)
 

--- a/src/renderkit/ui/main_window_logic.py
+++ b/src/renderkit/ui/main_window_logic.py
@@ -50,6 +50,7 @@ from renderkit.ui.qt_compat import (
     QSystemTrayIcon,
     Qt,
     QUrl,
+    qt_enum,
 )
 
 logger = logging.getLogger("renderkit.ui.main_window")
@@ -57,6 +58,9 @@ logger = logging.getLogger("renderkit.ui.main_window")
 RECENT_PATTERNS_LIMIT = 10
 RECENT_PATTERNS_KEY = "recent_patterns"
 RECENT_PATTERNS_CLEAR_LABEL = "Clear recent patterns"
+_QT_KEEP_ASPECT_RATIO = qt_enum("AspectRatioMode", "KeepAspectRatio")
+_QT_SMOOTH_TRANSFORMATION = qt_enum("TransformationMode", "SmoothTransformation")
+_QT_KEY_ESCAPE = qt_enum("Key", "Key_Escape")
 
 
 class MainWindowLogicMixin:
@@ -74,13 +78,7 @@ class MainWindowLogicMixin:
 
     def keyPressEvent(self, event) -> None:
         """Handle global key presses for the main window."""
-        escape_key = getattr(Qt, "Key_Escape", None)
-        if escape_key is None:
-            key_enum = getattr(Qt, "Key", None)
-            if key_enum is not None:
-                escape_key = getattr(key_enum, "Key_Escape", None)
-
-        if escape_key is not None and event.key() == escape_key:
+        if event.key() == _QT_KEY_ESCAPE:
             if self.worker and self.worker.isRunning():
                 self._cancel_conversion()
                 event.accept()
@@ -676,8 +674,8 @@ class MainWindowLogicMixin:
         target = QSize(max(1, int(width * scale)), max(1, int(height * scale)))
         return pixmap.scaled(
             target,
-            Qt.AspectRatioMode.KeepAspectRatio,
-            Qt.TransformationMode.SmoothTransformation,
+            _QT_KEEP_ASPECT_RATIO,
+            _QT_SMOOTH_TRANSFORMATION,
         )
 
     def _export_preview_thumbnail(self, pixmap) -> None:

--- a/src/renderkit/ui/main_window_ui.py
+++ b/src/renderkit/ui/main_window_ui.py
@@ -41,10 +41,15 @@ from renderkit.ui.qt_compat import (
     QToolButton,
     QVBoxLayout,
     QWidget,
+    qt_enum,
 )
 from renderkit.ui.widgets import PreviewWidget
 
 logger = logging.getLogger("renderkit.ui.main_window")
+
+_QT_ALIGN_CENTER = qt_enum("AlignmentFlag", "AlignCenter")
+_QT_ALIGN_LEFT = qt_enum("AlignmentFlag", "AlignLeft")
+_QT_ALIGN_RIGHT = qt_enum("AlignmentFlag", "AlignRight")
 
 
 class MainWindowUiMixin:
@@ -93,7 +98,7 @@ class MainWindowUiMixin:
 
         self.drop_overlay = QLabel("Drop file or folder anywhere", central_widget)
         self.drop_overlay.setObjectName("DropOverlay")
-        self.drop_overlay.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.drop_overlay.setAlignment(_QT_ALIGN_CENTER)
         self.drop_overlay.setVisible(False)
         self.drop_overlay.setAcceptDrops(True)
         self.drop_overlay.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
@@ -381,7 +386,7 @@ class MainWindowUiMixin:
             layout.setSpacing(spacing)
             return layout
 
-        align_left = Qt.AlignmentFlag.AlignLeft
+        align_left = _QT_ALIGN_LEFT
 
         # Output path
         output_path_layout = QHBoxLayout()
@@ -554,7 +559,7 @@ class MainWindowUiMixin:
         progress_header = QHBoxLayout()
         self.progress_status_icon = QLabel()
         self.progress_status_icon.setFixedSize(16, 16)
-        self.progress_status_icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.progress_status_icon.setAlignment(_QT_ALIGN_CENTER)
         progress_title = QLabel("Progress")
         progress_title.setStyleSheet("font-weight: 600;")
         progress_header.addWidget(self.progress_status_icon)
@@ -569,7 +574,7 @@ class MainWindowUiMixin:
         progress_layout.addWidget(self.progress_bar)
 
         self.progress_label = QLabel("Ready")
-        self.progress_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.progress_label.setAlignment(_QT_ALIGN_CENTER)
         self.progress_play_btn = QPushButton()
         self.progress_play_btn.setFixedSize(22, 22)
         self.progress_play_btn.setIcon(icon_manager.get_icon("play"))
@@ -648,10 +653,10 @@ class MainWindowUiMixin:
         timeline_row.setSpacing(6)
         self.timeline_start_label = QLabel("--")
         self.timeline_start_label.setObjectName("TimelineLabel")
-        self.timeline_start_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        self.timeline_start_label.setAlignment(_QT_ALIGN_LEFT)
         self.timeline_end_label = QLabel("--")
         self.timeline_end_label.setObjectName("TimelineLabel")
-        self.timeline_end_label.setAlignment(Qt.AlignmentFlag.AlignRight)
+        self.timeline_end_label.setAlignment(_QT_ALIGN_RIGHT)
         self.timeline_slider = JumpToClickSlider(Qt.Orientation.Horizontal)
         self.timeline_slider.setObjectName("TimelineSlider")
         self.timeline_slider.setTracking(True)
@@ -667,7 +672,7 @@ class MainWindowUiMixin:
 
         self.timeline_current_label = QLabel("Frame: -")
         self.timeline_current_label.setObjectName("TimelineCurrentLabel")
-        self.timeline_current_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.timeline_current_label.setAlignment(_QT_ALIGN_CENTER)
         self.timeline_current_label.setFixedHeight(18)
         timeline_layout.addWidget(self.timeline_current_label)
 

--- a/src/renderkit/ui/main_window_widgets.py
+++ b/src/renderkit/ui/main_window_widgets.py
@@ -13,9 +13,11 @@ from renderkit.ui.qt_compat import (
     QStyleOptionSlider,
     Qt,
     Signal,
+    qt_enum,
 )
 
 COMBO_POPUP_OBJECT_NAME = "ComboBoxPopup"
+_QT_LEFT_BUTTON = qt_enum("MouseButton", "LeftButton")
 try:
     MOUSE_MOVE_EVENT = QEvent.Type.MouseMove
 except AttributeError:
@@ -130,7 +132,7 @@ class JumpToClickSlider(NoWheelSlider):
     """Slider that jumps to the clicked position."""
 
     def mousePressEvent(self, event) -> None:
-        if event.button() == Qt.MouseButton.LeftButton:
+        if event.button() == _QT_LEFT_BUTTON:
             option = QStyleOptionSlider()
             self.initStyleOption(option)
             position = event.position().toPoint() if hasattr(event, "position") else event.pos()

--- a/src/renderkit/ui/preview_image.py
+++ b/src/renderkit/ui/preview_image.py
@@ -6,7 +6,8 @@ from typing import Any
 import numpy as np
 import OpenImageIO as oiio
 
-from renderkit.ui.qt_compat import QImage, QPixmap
+from renderkit.processing.pixels import float_pixels_to_uint8
+from renderkit.ui.qt_compat import QImage, QPixmap, resolve_enum_member
 
 
 @dataclass(frozen=True)
@@ -37,9 +38,7 @@ def imagebuf_to_preview_image(buf: oiio.ImageBuf) -> PreviewImageData:
         raise ValueError(f"Unsupported image channels: {channels}")
 
     if image.dtype != np.uint8:
-        image_f32 = image.astype(np.float32, copy=False)
-        image = np.clip(image_f32, 0.0, 1.0)
-        image = (image * np.float32(255.0)).astype(np.uint8)
+        image = float_pixels_to_uint8(image)
 
     image = np.ascontiguousarray(image)
     return PreviewImageData(
@@ -93,13 +92,7 @@ def _qimage_format(channels: int) -> Any:
     else:
         raise ValueError(f"Unsupported image channels: {channels}")
 
-    enum = getattr(QImage, "Format", None)
-    if enum is not None:
-        value = getattr(enum, name, None)
-        if value is not None:
-            return value
-
-    value = getattr(QImage, name, None)
-    if value is None:
-        raise ValueError(f"Qt image format is unavailable: {name}")
-    return value
+    try:
+        return resolve_enum_member(QImage, "Format", name)
+    except AttributeError as exc:
+        raise ValueError(f"Qt image format is unavailable: {name}") from exc

--- a/src/renderkit/ui/qt_compat.py
+++ b/src/renderkit/ui/qt_compat.py
@@ -233,6 +233,8 @@ __all__ = [
     "QWidget",
     # Backend info
     "QT_BACKEND_NAME",
+    "resolve_enum_member",
+    "qt_enum",
 ]
 
 
@@ -243,3 +245,22 @@ def get_qt_backend() -> str:
         Backend name: 'pyside6', 'pyside2', 'pyqt6', or 'pyqt5'
     """
     return QT_BACKEND_NAME
+
+
+def resolve_enum_member(owner, enum_name: str, member_name: str):
+    """Resolve Qt6 nested enum members with a Qt5 flat-attribute fallback."""
+    enum = getattr(owner, enum_name, None)
+    if enum is not None:
+        value = getattr(enum, member_name, None)
+        if value is not None:
+            return value
+
+    value = getattr(owner, member_name, None)
+    if value is None:
+        raise AttributeError(f"{owner!r} has no enum member {enum_name}.{member_name}")
+    return value
+
+
+def qt_enum(enum_name: str, member_name: str):
+    """Resolve a Qt enum member across supported Qt bindings."""
+    return resolve_enum_member(Qt, enum_name, member_name)

--- a/src/renderkit/ui/splash_screen.py
+++ b/src/renderkit/ui/splash_screen.py
@@ -12,10 +12,14 @@ from renderkit.ui.qt_compat import (
     QPainter,
     QPixmap,
     QSplashScreen,
-    Qt,
+    qt_enum,
 )
 
 SPLASH_MIN_DURATION_MS = 1200
+_QT_ALIGN_LEFT = qt_enum("AlignmentFlag", "AlignLeft")
+_QT_ALIGN_VCENTER = qt_enum("AlignmentFlag", "AlignVCenter")
+_QT_FRAMELESS_WINDOW_HINT = qt_enum("WindowType", "FramelessWindowHint")
+_QT_NO_PEN = qt_enum("PenStyle", "NoPen")
 
 
 def compute_remaining_splash_ms(
@@ -75,7 +79,7 @@ def build_splash_pixmap(version: str, width: int = 620, height: int = 320) -> QP
     card_width = width - (card_margin * 2)
     card_height = height - (card_margin * 2)
 
-    painter.setPen(Qt.PenStyle.NoPen)
+    painter.setPen(_QT_NO_PEN)
     painter.setBrush(QColor(0, 0, 0, 90))
     painter.drawRoundedRect(card_x + 3, card_y + 5, card_width, card_height, 18, 18)
     painter.setBrush(QColor("#111923"))
@@ -102,7 +106,7 @@ def build_splash_pixmap(version: str, width: int = 620, height: int = 320) -> QP
         text_x = icon_x + icon_size + 18
 
     text_width = card_x + card_width - text_x - 30
-    align = Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+    align = _QT_ALIGN_LEFT | _QT_ALIGN_VCENTER
 
     title_font = QFont("Segoe UI", 30)
     title_font.setBold(True)
@@ -146,10 +150,9 @@ def build_splash_pixmap(version: str, width: int = 620, height: int = 320) -> QP
 def create_splash_screen(version: str) -> QSplashScreen:
     """Create and configure the application splash screen."""
     splash = QSplashScreen(build_splash_pixmap(version))
-    window_type = getattr(Qt, "WindowType", None)
-    if window_type is not None:
-        splash.setWindowFlag(window_type.FramelessWindowHint, True)
+    if hasattr(splash, "setWindowFlag"):
+        splash.setWindowFlag(_QT_FRAMELESS_WINDOW_HINT, True)
     else:
-        splash.setWindowFlags(Qt.FramelessWindowHint)
+        splash.setWindowFlags(_QT_FRAMELESS_WINDOW_HINT)
     splash.setEnabled(False)
     return splash

--- a/src/renderkit/ui/widgets.py
+++ b/src/renderkit/ui/widgets.py
@@ -33,15 +33,38 @@ from renderkit.ui.qt_compat import (
     QScrollArea,
     QSize,
     QSizePolicy,
-    Qt,
     QThread,
     QTimer,
     QVBoxLayout,
     QWidget,
     Signal,
+    qt_enum,
 )
 
 logger = logging.getLogger(__name__)
+
+_PREVIEW_LABEL_COLOR = "#888"
+_PREVIEW_LABEL_ERROR_COLOR = "#f44336"
+_QT_ALIGN_CENTER = qt_enum("AlignmentFlag", "AlignCenter")
+_QT_KEEP_ASPECT_RATIO = qt_enum("AspectRatioMode", "KeepAspectRatio")
+_QT_SMOOTH_TRANSFORMATION = qt_enum("TransformationMode", "SmoothTransformation")
+_QT_MIDDLE_BUTTON = qt_enum("MouseButton", "MiddleButton")
+_QT_CLOSED_HAND_CURSOR = qt_enum("CursorShape", "ClosedHandCursor")
+_QT_POINTING_HAND_CURSOR = qt_enum("CursorShape", "PointingHandCursor")
+_QT_KEY_ESCAPE = qt_enum("Key", "Key_Escape")
+_QT_KEY_F = qt_enum("Key", "Key_F")
+_QT_NON_MODAL = qt_enum("WindowModality", "NonModal")
+
+
+def _preview_label_stylesheet(color: str = _PREVIEW_LABEL_COLOR) -> str:
+    return f"""
+            QLabel {{
+                background-color: #2b2b2b;
+                color: {color};
+                border: 1px solid #444;
+                border-radius: 4px;
+            }}
+        """
 
 
 def _scaled_burnin_config_for_preview(
@@ -222,11 +245,11 @@ class FullscreenPreviewWindow(QWidget):
         # Scroll area for zooming and panning
         self.scroll_area = ZoomableScrollArea()
         self.scroll_area.setWidgetResizable(True)
-        self.scroll_area.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.scroll_area.setAlignment(_QT_ALIGN_CENTER)
         self.scroll_area.setStyleSheet("background-color: #111; border: none;")
 
         self.image_label = QLabel()
-        self.image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.image_label.setAlignment(_QT_ALIGN_CENTER)
         self.scroll_area.setWidget(self.image_label)
 
         layout.addWidget(self.scroll_area, 1)
@@ -301,8 +324,8 @@ class FullscreenPreviewWindow(QWidget):
         scaled = self._pixmap.scaled(
             new_width,
             new_height,
-            Qt.AspectRatioMode.KeepAspectRatio,
-            Qt.TransformationMode.SmoothTransformation,
+            _QT_KEEP_ASPECT_RATIO,
+            _QT_SMOOTH_TRANSFORMATION,
         )
         self.image_label.setPixmap(scaled)
 
@@ -349,10 +372,10 @@ class FullscreenPreviewWindow(QWidget):
 
     def mousePressEvent(self, event) -> None:
         """Start panning on middle click."""
-        if event.button() == Qt.MouseButton.MiddleButton:
+        if event.button() == _QT_MIDDLE_BUTTON:
             self._is_panning = True
             self._last_mouse_pos = event.pos()
-            self.setCursor(Qt.CursorShape.ClosedHandCursor)
+            self.setCursor(_QT_CLOSED_HAND_CURSOR)
             event.accept()
         super().mousePressEvent(event)
 
@@ -371,7 +394,7 @@ class FullscreenPreviewWindow(QWidget):
 
     def mouseReleaseEvent(self, event) -> None:
         """Stop panning."""
-        if event.button() == Qt.MouseButton.MiddleButton:
+        if event.button() == _QT_MIDDLE_BUTTON:
             self._is_panning = False
             self.unsetCursor()
             event.accept()
@@ -379,9 +402,9 @@ class FullscreenPreviewWindow(QWidget):
 
     def keyPressEvent(self, event) -> None:
         """Handle key press events."""
-        if event.key() == Qt.Key.Key_Escape:
+        if event.key() == _QT_KEY_ESCAPE:
             self.close()
-        elif event.key() == Qt.Key.Key_F:  # 'F' key to re-fit
+        elif event.key() == _QT_KEY_F:  # 'F' key to re-fit
             self._fit_to_window()
         super().keyPressEvent(event)
 
@@ -417,17 +440,10 @@ class PreviewWidget(QWidget):
         container_layout.setContentsMargins(0, 0, 0, 0)
 
         self.preview_label = QLabel("No preview")
-        self.preview_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.preview_label.setAlignment(_QT_ALIGN_CENTER)
         self.preview_label.setMinimumSize(240, 180)
         self.preview_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        self.preview_label.setStyleSheet("""
-            QLabel {
-                background-color: #2b2b2b;
-                color: #888;
-                border: 1px solid #444;
-                border-radius: 4px;
-            }
-        """)
+        self._set_preview_label_style()
         self.preview_label.setScaledContents(False)
         container_layout.addWidget(self.preview_label)
 
@@ -436,7 +452,7 @@ class PreviewWidget(QWidget):
         self.expand_btn.setIcon(icon_manager.get_icon("scan"))
         self.expand_btn.setFixedSize(30, 30)
         self.expand_btn.setToolTip("Fullscreen Preview")
-        self.expand_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.expand_btn.setCursor(_QT_POINTING_HAND_CURSOR)
         self.expand_btn.setStyleSheet("""
             QPushButton {
                 background-color: rgba(45, 45, 45, 0.7);
@@ -456,7 +472,7 @@ class PreviewWidget(QWidget):
         self.export_btn.setIcon(icon_manager.get_icon("file_image"))
         self.export_btn.setFixedSize(30, 30)
         self.export_btn.setToolTip("Export JPEG thumbnail")
-        self.export_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.export_btn.setCursor(_QT_POINTING_HAND_CURSOR)
         self.export_btn.clicked.connect(self._request_thumbnail_export)
         self.export_btn.hide()
 
@@ -516,14 +532,7 @@ class PreviewWidget(QWidget):
 
         self._original_pixmap = None
         self.preview_label.setText("Loading preview...")
-        self.preview_label.setStyleSheet("""
-            QLabel {
-                background-color: #2b2b2b;
-                color: #888;
-                border: 1px solid #444;
-                border-radius: 4px;
-            }
-        """)
+        self._set_preview_label_style()
 
         self.worker = PreviewWorker(
             file_path,
@@ -563,7 +572,7 @@ class PreviewWidget(QWidget):
             return
 
         self.fullscreen_win = FullscreenPreviewWindow(self._original_pixmap, "RenderKit - Preview")
-        self.fullscreen_win.setWindowModality(Qt.WindowModality.NonModal)
+        self.fullscreen_win.setWindowModality(_QT_NON_MODAL)
         self.fullscreen_win.show()
 
     def _on_preview_error(self, error: str) -> None:
@@ -572,14 +581,7 @@ class PreviewWidget(QWidget):
         self.preview_label.setText(f"Preview error:\n{error}")
         self.expand_btn.hide()
         self.export_btn.hide()
-        self.preview_label.setStyleSheet("""
-            QLabel {
-                background-color: #2b2b2b;
-                color: #f44336;
-                border: 1px solid #444;
-                border-radius: 4px;
-            }
-        """)
+        self._set_preview_label_style(error=True)
 
     def clear_preview(self) -> None:
         """Clear the preview."""
@@ -588,14 +590,7 @@ class PreviewWidget(QWidget):
         self.preview_label.setText("No preview")
         self.expand_btn.hide()
         self.export_btn.hide()
-        self.preview_label.setStyleSheet("""
-            QLabel {
-                background-color: #2b2b2b;
-                color: #888;
-                border: 1px solid #444;
-                border-radius: 4px;
-            }
-        """)
+        self._set_preview_label_style()
 
     def _request_thumbnail_export(self) -> None:
         """Emit request to export a preview thumbnail."""
@@ -614,7 +609,11 @@ class PreviewWidget(QWidget):
 
         scaled = self._original_pixmap.scaled(
             target_size,
-            Qt.AspectRatioMode.KeepAspectRatio,
-            Qt.TransformationMode.SmoothTransformation,
+            _QT_KEEP_ASPECT_RATIO,
+            _QT_SMOOTH_TRANSFORMATION,
         )
         self.preview_label.setPixmap(scaled)
+
+    def _set_preview_label_style(self, *, error: bool = False) -> None:
+        color = _PREVIEW_LABEL_ERROR_COLOR if error else _PREVIEW_LABEL_COLOR
+        self.preview_label.setStyleSheet(_preview_label_stylesheet(color))


### PR DESCRIPTION
## Summary
- centralize numbered frame-name parsing for batch discovery and sequence replacement
- centralize OpenImageIO import/float-buffer helpers and shared float pixel to uint8 conversion
- route repeated Qt enum lookups and preview-label styling through shared helpers/constants

## Validation
- uv --native-tls run ruff check src/renderkit tests
- uv --native-tls run ruff format --check src/renderkit tests
- uv --native-tls run --extra dev pytest
- uv --native-tls run --extra dev pytest tests/test_ui_splash.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized OpenImageIO library dependency handling to reduce code duplication across modules.
  * Extracted frame sequence parsing utilities into a shared module for consistent numeric frame name discovery.
  * Added internal pixel conversion utilities for standardized float-to-uint8 conversion.
  * Improved Qt framework enum compatibility layer to better support cross-version compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->