### PR TITLE
[codex] Extract magic literal constants

### DIFF
--- a/src/renderkit/cli/main.py
+++ b/src/renderkit/cli/main.py
@@ -34,6 +34,7 @@ from renderkit.io.image_reader import ImageReaderFactory
 from renderkit.io.oiio_cache import get_shared_image_cache
 from renderkit.io.oiio_utils import require_oiio
 from renderkit.logging_utils import setup_logging
+from renderkit.processing.contact_sheet import compute_contact_sheet_label_metrics
 from renderkit.processing.scaler import ImageScaler
 
 logger = logging.getLogger("renderkit.cli.main")
@@ -53,13 +54,6 @@ def _launch_ui() -> None:
     from renderkit.ui.main_window import run_ui
 
     run_ui()
-
-
-def _label_height(config: ContactSheetConfig) -> int:
-    if not config.show_labels:
-        return 0
-    label_gap = max(4, int(config.font_size * 0.01))
-    return label_gap + int(config.font_size * 1.4)
 
 
 def _to_rgb_buf(oiio: Any, buf: Any) -> Any:
@@ -103,8 +97,7 @@ def _write_sequence_contact_sheet(
     first_spec = first_buf.spec()
     thumb_w, thumb_h = config.resolve_layer_size(first_spec.width, first_spec.height)
     padding = config.padding
-    label_h = _label_height(config)
-    label_gap = max(4, int(config.font_size * 0.01)) if config.show_labels else 0
+    label_gap, label_h = compute_contact_sheet_label_metrics(config)
     cell_w = thumb_w + (padding * 2)
     cell_h = thumb_h + (padding * 2) + label_h
     rows = (len(frame_numbers) + config.columns - 1) // config.columns

--- a/src/renderkit/core/converter.py
+++ b/src/renderkit/core/converter.py
@@ -21,7 +21,10 @@ from renderkit.io.image_reader import ImageReader, ImageReaderFactory, LayerMapE
 from renderkit.io.oiio_cache import get_shared_image_cache
 from renderkit.processing.burnin import BurnInProcessor
 from renderkit.processing.color_space import ColorSpaceConverter, ColorSpacePreset
-from renderkit.processing.contact_sheet import ContactSheetGenerator
+from renderkit.processing.contact_sheet import (
+    ContactSheetGenerator,
+    compute_contact_sheet_label_metrics,
+)
 from renderkit.processing.frame_pipeline import FramePreparationOptions, prepare_frame_buffer
 from renderkit.processing.scaler import ImageScaler
 from renderkit.processing.video_encoder import VideoEncoder
@@ -257,9 +260,7 @@ class SequenceConverter:
                 thumb_w, thumb_h = cs_config.resolve_layer_size(width, height)
 
                 padding = cs_config.padding
-                label_h = 0
-                if cs_config.show_labels:
-                    label_h = int(cs_config.font_size * 2.5)
+                _, label_h = compute_contact_sheet_label_metrics(cs_config)
 
                 cell_w = thumb_w + (padding * 2)
                 cell_h = thumb_h + (padding * 2) + label_h

--- a/src/renderkit/core/ffmpeg_utils.py
+++ b/src/renderkit/core/ffmpeg_utils.py
@@ -9,6 +9,8 @@ import sys
 from pathlib import Path
 from typing import Any, Optional
 
+_FFMPEG_ENV_VAR = "IMAGEIO_FFMPEG_EXE"
+
 logger = logging.getLogger(__name__)
 
 
@@ -37,7 +39,7 @@ def _get_vendor_ffmpeg_candidates(root: Path) -> list[Path]:
 
 def ensure_ffmpeg_env() -> None:
     """Set IMAGEIO_FFMPEG_EXE if a bundled FFmpeg binary is available."""
-    if os.environ.get("IMAGEIO_FFMPEG_EXE"):
+    if os.environ.get(_FFMPEG_ENV_VAR):
         return
 
     candidates: list[Path] = []
@@ -73,7 +75,7 @@ def ensure_ffmpeg_env() -> None:
 
     for candidate in candidates:
         if candidate.is_file():
-            os.environ["IMAGEIO_FFMPEG_EXE"] = str(candidate)
+            os.environ[_FFMPEG_ENV_VAR] = str(candidate)
             logger.info("Using bundled ffmpeg: %s", candidate)
             return
 
@@ -82,12 +84,12 @@ def ensure_ffmpeg_env() -> None:
 
 def get_ffmpeg_exe() -> str:
     """Return the best FFmpeg executable path for the current environment."""
-    env_exe = os.environ.get("IMAGEIO_FFMPEG_EXE")
+    env_exe = os.environ.get(_FFMPEG_ENV_VAR)
     if env_exe:
         return env_exe
 
     ensure_ffmpeg_env()
-    env_exe = os.environ.get("IMAGEIO_FFMPEG_EXE")
+    env_exe = os.environ.get(_FFMPEG_ENV_VAR)
     if env_exe:
         return env_exe
 

--- a/src/renderkit/core/sequence_replacement.py
+++ b/src/renderkit/core/sequence_replacement.py
@@ -19,6 +19,7 @@ from renderkit.core.sequence_names import split_numbered_frame_name
 from renderkit.exceptions import SequenceReplacementError
 
 Mp4Verifier = Callable[[Path], None]
+_DEFAULT_AUDIT_FILENAME = "renderkit-replacement-audit.jsonl"
 
 
 @dataclass(frozen=True)
@@ -130,7 +131,7 @@ def replace_sequence_with_mp4(
 
     source_mp4 = output_mp4.resolve()
     destination_mp4 = sequence.base_path / output_mp4.name
-    report_path = audit_report or (sequence.base_path / "renderkit-replacement-audit.jsonl")
+    report_path = audit_report or (sequence.base_path / _DEFAULT_AUDIT_FILENAME)
     _prepare_audit_report(report_path)
     verified = _verify_source_mp4_if_needed(
         source_mp4,

--- a/src/renderkit/logging_utils.py
+++ b/src/renderkit/logging_utils.py
@@ -10,6 +10,9 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 _LOGGER_NAME = "renderkit"
+_QT_DELETED_SIGNAL_ERROR_MSG = "SignalInstance object was already deleted"
+_LOG_FILE_MAX_BYTES = 5 * 1024 * 1024
+_LOG_FILE_BACKUP_COUNT = 3
 
 
 class CallbackHandler(logging.Handler):
@@ -27,7 +30,7 @@ class CallbackHandler(logging.Handler):
         try:
             self._callback(msg)
         except RuntimeError as exc:
-            if "SignalInstance object was already deleted" in str(exc):
+            if _QT_DELETED_SIGNAL_ERROR_MSG in str(exc):
                 return
             self.handleError(record)
         except Exception:
@@ -103,8 +106,8 @@ def setup_logging(
     if file_handler is None:
         file_handler = RotatingFileHandler(
             log_path,
-            maxBytes=5 * 1024 * 1024,
-            backupCount=3,
+            maxBytes=_LOG_FILE_MAX_BYTES,
+            backupCount=_LOG_FILE_BACKUP_COUNT,
             encoding="utf-8",
         )
         file_handler.renderkit_handler = "file"

--- a/src/renderkit/processing/burnin.py
+++ b/src/renderkit/processing/burnin.py
@@ -3,6 +3,10 @@ from typing import Any
 
 from renderkit.io.oiio_utils import require_oiio
 
+_BURNIN_EDGE_MARGIN = 20
+_BURNIN_BAR_HEIGHT_MULTIPLIER = 2.0
+_BURNIN_VERTICAL_CENTER_FACTOR = 0.7
+
 logger = logging.getLogger(__name__)
 
 
@@ -39,7 +43,7 @@ class BurnInProcessor:
         if getattr(burnin_config, "use_background", False):
             # Bar height based on max font size (roughly)
             max_font_size = max([e.font_size for e in burnin_config.elements])
-            bar_height = int(max_font_size * 2.0)
+            bar_height = int(max_font_size * _BURNIN_BAR_HEIGHT_MULTIPLIER)
 
             # Darken the area by multiplying
             # background_opacity 30 means 30% darkening -> multiplier 0.7
@@ -59,16 +63,16 @@ class BurnInProcessor:
                 if element.alignment == "center":
                     x_pos = width // 2
                 elif element.alignment == "right":
-                    x_pos = width - 20
+                    x_pos = width - _BURNIN_EDGE_MARGIN
                 elif element.alignment == "left":
-                    x_pos = 20
+                    x_pos = _BURNIN_EDGE_MARGIN
 
             # Apply burn-in
             # Adjust Y to be within the bar if background is used
             y_pos = element.y
             if getattr(burnin_config, "use_background", False) and y_pos < bar_height:
                 # Center vertically in bar (render_text base is baseline)
-                y_pos = int(bar_height * 0.7)
+                y_pos = int(bar_height * _BURNIN_VERTICAL_CENTER_FACTOR)
 
             if not self.oiio.ImageBufAlgo.render_text(
                 buf,

--- a/src/renderkit/processing/contact_sheet.py
+++ b/src/renderkit/processing/contact_sheet.py
@@ -12,7 +12,20 @@ from renderkit.io.image_reader import ImageReader, ImageReaderFactory, LayerMapE
 from renderkit.io.oiio_cache import get_shared_image_cache
 from renderkit.processing.scaler import ImageScaler
 
+_CS_LABEL_GAP_MULTIPLIER = 0.01
+_CS_LABEL_MIN_GAP = 4
+_CS_LINE_HEIGHT_MULTIPLIER = 1.4
+
 logger = logging.getLogger(__name__)
+
+
+def compute_contact_sheet_label_metrics(config: ContactSheetConfig) -> tuple[int, int]:
+    """Return label gap and label height for a contact sheet config."""
+    if not config.show_labels:
+        return 0, 0
+    label_gap = max(_CS_LABEL_MIN_GAP, int(config.font_size * _CS_LABEL_GAP_MULTIPLIER))
+    label_h = label_gap + int(config.font_size * _CS_LINE_HEIGHT_MULTIPLIER)
+    return label_gap, label_h
 
 
 class ContactSheetGenerator:
@@ -172,11 +185,7 @@ class ContactSheetGenerator:
         }
 
     def _compute_label_metrics(self) -> tuple[int, int]:
-        if not self.config.show_labels:
-            return 0, 0
-        label_gap = max(4, int(self.config.font_size * 0.01))
-        label_h = label_gap + int(self.config.font_size * 1.4)
-        return label_gap, label_h
+        return compute_contact_sheet_label_metrics(self.config)
 
     def _build_subimage_buffers(
         self,

--- a/src/renderkit/processing/video_encoder.py
+++ b/src/renderkit/processing/video_encoder.py
@@ -18,6 +18,22 @@ from renderkit.exceptions import ConfigurationError, VideoEncodingError
 from renderkit.processing.pixels import float_pixels_to_uint8
 from renderkit.processing.scaler import ImageScaler
 
+_FFREPORT_ENV_VAR = "FFREPORT"
+_FFMPEG_REPORT_VERBOSITY_LEVEL = 48
+_FFMPEG_REPORT_MAX_TAIL_LINES = 80
+_QUALITY_MAX = 10
+_X26X_CRF_BEST = 18
+_X26X_CRF_STEP = 1.7
+_X26X_CRF_DEFAULT = 23
+_AV1_CRF_BEST = 20
+_AV1_CRF_STEP = 3
+_AV1_CRF_DEFAULT = 32
+_AV1_CPU_USED = "6"
+_AV1_CRF_BITRATE = "0"
+_MPEG4_QV_BEST = 2
+_MPEG4_QV_STEP = 2.9
+_MPEG4_QV_DEFAULT = 4
+
 logger = logging.getLogger(__name__)
 
 
@@ -224,7 +240,7 @@ class VideoEncoder:
             macro_block_size: Macro block size for codec compatibility (default: 16)
                              Frame dimensions will be rounded up to multiples of this value
         """
-        if quality is not None and not 0 <= quality <= 10:
+        if quality is not None and not 0 <= quality <= _QUALITY_MAX:
             raise ConfigurationError("Quality must be between 0 and 10")
 
         self.output_path = output_path.absolute()
@@ -254,12 +270,14 @@ class VideoEncoder:
             path = Path(value).expanduser()
         path.parent.mkdir(parents=True, exist_ok=True)
 
-        if "FFREPORT" in os.environ:
-            self._ffreport_prev = os.environ["FFREPORT"]
+        if _FFREPORT_ENV_VAR in os.environ:
+            self._ffreport_prev = os.environ[_FFREPORT_ENV_VAR]
         else:
             self._ffreport_prev = None
         escaped_path = _escape_ffreport_path(path)
-        os.environ["FFREPORT"] = f"file={escaped_path}:level=48"
+        os.environ[_FFREPORT_ENV_VAR] = (
+            f"file={escaped_path}:level={_FFMPEG_REPORT_VERBOSITY_LEVEL}"
+        )
         self._ffreport_set = True
         return path
 
@@ -267,12 +285,14 @@ class VideoEncoder:
         if not self._ffreport_set:
             return
         if self._ffreport_prev is None:
-            os.environ.pop("FFREPORT", None)
+            os.environ.pop(_FFREPORT_ENV_VAR, None)
         else:
-            os.environ["FFREPORT"] = self._ffreport_prev
+            os.environ[_FFREPORT_ENV_VAR] = self._ffreport_prev
         self._ffreport_set = False
 
-    def _read_ffmpeg_report_tail(self, max_lines: int = 80) -> Optional[str]:
+    def _read_ffmpeg_report_tail(
+        self, max_lines: int = _FFMPEG_REPORT_MAX_TAIL_LINES
+    ) -> Optional[str]:
         """Best-effort FFmpeg report tail for error messages."""
         if self._ffmpeg_report_path is None:
             return None
@@ -394,30 +414,42 @@ class VideoEncoder:
         if self.bitrate is not None:
             bitrate = f"{self.bitrate}k"
             if ffmpeg_codec == "libaom-av1":
-                ffmpeg_params.extend(["-cpu-used", "6"])
+                ffmpeg_params.extend(["-cpu-used", _AV1_CPU_USED])
             logger.debug("%s tuning: bitrate=%s", ffmpeg_codec, bitrate)
         # Codec-specific tuning and quality mapping (used only when bitrate is not provided).
         elif ffmpeg_codec in ["libx264", "libx265"]:
             # Map quality (0-10) to CRF (35-18)
             # 10 -> 18 (Excellent), 0 -> 35 (Low quality)
             # Default to 23 if not specified
-            crf = 18 + (10 - self.quality) * 1.7 if self.quality is not None else 23
+            crf = (
+                _X26X_CRF_BEST + (_QUALITY_MAX - self.quality) * _X26X_CRF_STEP
+                if self.quality is not None
+                else _X26X_CRF_DEFAULT
+            )
             ffmpeg_params.extend(["-crf", f"{int(crf)}"])
             logger.debug(f"{ffmpeg_codec} tuning: crf={int(crf)}")
 
         elif ffmpeg_codec == "libaom-av1":
             # AV1 is extremely slow by default. Use -cpu-used 6 for better speed.
             # Map 0-10 quality to CRF 50-20 (lower is better)
-            crf = 20 + (10 - self.quality) * 3 if self.quality is not None else 32
-            ffmpeg_params.extend(["-crf", f"{int(crf)}", "-cpu-used", "6"])
+            crf = (
+                _AV1_CRF_BEST + (_QUALITY_MAX - self.quality) * _AV1_CRF_STEP
+                if self.quality is not None
+                else _AV1_CRF_DEFAULT
+            )
+            ffmpeg_params.extend(["-crf", f"{int(crf)}", "-cpu-used", _AV1_CPU_USED])
             # libaom-av1 needs bitrate=0 to enable CRF mode in FFmpeg
-            bitrate = "0"
+            bitrate = _AV1_CRF_BITRATE
             logger.debug(f"AV1 tuning: crf={int(crf)}, cpu-used=6")
 
         elif ffmpeg_codec == "mpeg4":
             # Map quality (0-10) to -q:v (31-2)
             # Higher -q:v is lower quality.
-            qv = 2 + (10 - self.quality) * 2.9 if self.quality is not None else 4
+            qv = (
+                _MPEG4_QV_BEST + (_QUALITY_MAX - self.quality) * _MPEG4_QV_STEP
+                if self.quality is not None
+                else _MPEG4_QV_DEFAULT
+            )
             ffmpeg_params.extend(["-q:v", f"{int(qv)}"])
             logger.debug(f"MPEG-4 tuning: q:v={int(qv)}")
 

--- a/src/renderkit/ui/main_window_logic.py
+++ b/src/renderkit/ui/main_window_logic.py
@@ -53,14 +53,19 @@ from renderkit.ui.qt_compat import (
     qt_enum,
 )
 
-logger = logging.getLogger("renderkit.ui.main_window")
-
 RECENT_PATTERNS_LIMIT = 10
 RECENT_PATTERNS_KEY = "recent_patterns"
 RECENT_PATTERNS_CLEAR_LABEL = "Clear recent patterns"
+_PREVIEW_DEBOUNCE_MS = 300
+_THUMBNAIL_MAX_DIM = 512
+_THUMBNAIL_JPEG_QUALITY = 90
+_LOG_SEPARATOR_WIDTH = 50
+_CONTACT_SHEET_DEFAULT_COLUMNS = ContactSheetConfig().columns
 _QT_KEEP_ASPECT_RATIO = qt_enum("AspectRatioMode", "KeepAspectRatio")
 _QT_SMOOTH_TRANSFORMATION = qt_enum("TransformationMode", "SmoothTransformation")
 _QT_KEY_ESCAPE = qt_enum("Key", "Key_Escape")
+
+logger = logging.getLogger("renderkit.ui.main_window")
 
 
 class MainWindowLogicMixin:
@@ -512,7 +517,7 @@ class MainWindowLogicMixin:
     def _on_cs_setting_changed(self, *args) -> None:
         """Handle contact sheet or preview setting changes with debouncing."""
         # Trigger preview update after a short delay to avoid thread churning
-        self._cs_preview_timer.start(300)  # 300ms debounce
+        self._cs_preview_timer.start(_PREVIEW_DEBOUNCE_MS)
 
     def _on_quality_changed(self, value: int) -> None:
         """Handle quality slider change."""
@@ -663,12 +668,11 @@ class MainWindowLogicMixin:
     def _scale_thumbnail_pixmap(self, pixmap):
         if pixmap.isNull():
             return pixmap
-        max_dim = 512
         width = pixmap.width()
         height = pixmap.height()
         if width <= 0 or height <= 0:
             return pixmap
-        scale = min(1.0, max_dim / float(width), max_dim / float(height))
+        scale = min(1.0, _THUMBNAIL_MAX_DIM / float(width), _THUMBNAIL_MAX_DIM / float(height))
         if scale >= 1.0:
             return pixmap
         target = QSize(max(1, int(width * scale)), max(1, int(height * scale)))
@@ -712,7 +716,7 @@ class MainWindowLogicMixin:
 
         thumb_path = output_dir / f"{sequence_stem}_thumb.jpg"
         scaled = self._scale_thumbnail_pixmap(pixmap)
-        saved = scaled.save(str(thumb_path), "JPEG", 90)
+        saved = scaled.save(str(thumb_path), "JPEG", _THUMBNAIL_JPEG_QUALITY)
         if not saved:
             QMessageBox.warning(
                 self,
@@ -1184,7 +1188,7 @@ class MainWindowLogicMixin:
             current_cols = self.cs_columns_spin.value()
             if current_cols > max_cols:
                 self.cs_columns_spin.setValue(max_cols)
-            elif current_cols == 4:
+            elif current_cols == _CONTACT_SHEET_DEFAULT_COLUMNS:
                 self.cs_columns_spin.setValue(suggested_cols)
 
             # Update FPS if available
@@ -1249,7 +1253,7 @@ class MainWindowLogicMixin:
         self.cs_columns_spin.setMaximum(1)
         if self.cs_columns_spin.value() > 1:
             self.cs_columns_spin.setValue(1)
-        elif self.cs_columns_spin.value() == 4:
+        elif self.cs_columns_spin.value() == _CONTACT_SHEET_DEFAULT_COLUMNS:
             self.cs_columns_spin.setValue(1)
 
         # Update sequence info
@@ -1444,7 +1448,7 @@ class MainWindowLogicMixin:
         self.progress_bar.setRange(0, 0)  # Indeterminate
         self.progress_label.setText("Starting conversion...")
         self.statusBar().showMessage("Starting conversion...")
-        logger.info("=" * 50)
+        logger.info("=" * _LOG_SEPARATOR_WIDTH)
         logger.info("Starting conversion...")
         logger.info(f"Input: {config.input_pattern}")
         logger.info(f"Output: {config.output_path}")

--- a/src/renderkit/ui/main_window_ui.py
+++ b/src/renderkit/ui/main_window_ui.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 from renderkit import __version__
+from renderkit.core.config import ContactSheetConfig
 from renderkit.ui.icons import icon_manager
 from renderkit.ui.main_window_widgets import (
     JumpToClickSlider,
@@ -45,11 +46,21 @@ from renderkit.ui.qt_compat import (
 )
 from renderkit.ui.widgets import PreviewWidget
 
-logger = logging.getLogger("renderkit.ui.main_window")
-
+_MIN_WINDOW_WIDTH = 500
+_MIN_WINDOW_HEIGHT = 450
+_DEFAULT_WINDOW_WIDTH = 1400
+_DEFAULT_WINDOW_HEIGHT = 950
+_COMPACT_HEIGHT_THRESHOLD = 900
+_COMFORTABLE_HEIGHT_THRESHOLD = 1100
+_LOG_MAX_BLOCK_COUNT = 1000
+_TIMELINE_MAX_HEIGHT = 54
+_CONTACT_SHEET_DEFAULT_COLUMNS = ContactSheetConfig().columns
+_CONTACT_SHEET_DEFAULT_PADDING = ContactSheetConfig().padding
 _QT_ALIGN_CENTER = qt_enum("AlignmentFlag", "AlignCenter")
 _QT_ALIGN_LEFT = qt_enum("AlignmentFlag", "AlignLeft")
 _QT_ALIGN_RIGHT = qt_enum("AlignmentFlag", "AlignRight")
+
+logger = logging.getLogger("renderkit.ui.main_window")
 
 
 class MainWindowUiMixin:
@@ -75,8 +86,8 @@ class MainWindowUiMixin:
     def _setup_ui(self) -> None:
         """Set up the user interface."""
         self.setWindowTitle(f"RenderKit v{__version__}")
-        self.setMinimumSize(500, 450)
-        self.resize(1400, 950)
+        self.setMinimumSize(_MIN_WINDOW_WIDTH, _MIN_WINDOW_HEIGHT)
+        self.resize(_DEFAULT_WINDOW_WIDTH, _DEFAULT_WINDOW_HEIGHT)
         self._last_preview_path: Optional[Path] = None
 
         # Central widget with splitter
@@ -177,9 +188,9 @@ class MainWindowUiMixin:
         height = event.size().height()
 
         # Determine layout mode based on height
-        if height < 900:
+        if height < _COMPACT_HEIGHT_THRESHOLD:
             new_mode = "compact"
-        elif height < 1100:
+        elif height < _COMFORTABLE_HEIGHT_THRESHOLD:
             new_mode = "standard"
         else:
             new_mode = "comfortable"
@@ -195,7 +206,7 @@ class MainWindowUiMixin:
                 self._apply_comfortable_mode()
 
     def _apply_compact_mode(self):
-        """Apply compact layout for small windows (<900px)."""
+        """Apply compact layout for small windows."""
         if self.preview_panel:
             self.preview_panel.setVisible(False)
         # Adjust splitter to give more space to settings
@@ -203,7 +214,7 @@ class MainWindowUiMixin:
             self.main_splitter.setSizes([800, 200])
 
     def _apply_standard_mode(self):
-        """Apply standard layout (900-1100px)."""
+        """Apply standard layout."""
         if self.preview_panel:
             self.preview_panel.setVisible(True)
         # Standard splitter sizes
@@ -213,7 +224,7 @@ class MainWindowUiMixin:
             self.left_splitter.setSizes([400, 180])
 
     def _apply_comfortable_mode(self):
-        """Apply comfortable layout for large windows (>1100px)."""
+        """Apply comfortable layout for large windows."""
         if self.preview_panel:
             self.preview_panel.setVisible(True)
         # Give the right-side preview column more room while keeping logs readable.
@@ -611,7 +622,7 @@ class MainWindowUiMixin:
         self.log_text = QPlainTextEdit()
         self.log_text.setReadOnly(True)
         self.log_text.setFont(QFont("Consolas", 9))
-        self.log_text.setMaximumBlockCount(1000)  # Limit log lines
+        self.log_text.setMaximumBlockCount(_LOG_MAX_BLOCK_COUNT)
         self.log_text.setObjectName("LogBox")
         log_layout.addWidget(self.log_text)
 
@@ -643,7 +654,7 @@ class MainWindowUiMixin:
         self.timeline_widget = QWidget()
         self.timeline_widget.setObjectName("TimelineWidget")
         self.timeline_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        self.timeline_widget.setMaximumHeight(54)
+        self.timeline_widget.setMaximumHeight(_TIMELINE_MAX_HEIGHT)
         timeline_layout = QVBoxLayout(self.timeline_widget)
         timeline_layout.setContentsMargins(6, 2, 6, 2)
         timeline_layout.setSpacing(2)
@@ -836,12 +847,12 @@ class MainWindowUiMixin:
 
         self.cs_columns_spin = NoWheelSpinBox()
         self.cs_columns_spin.setRange(1, 20)
-        self.cs_columns_spin.setValue(4)
+        self.cs_columns_spin.setValue(_CONTACT_SHEET_DEFAULT_COLUMNS)
         form_layout.addRow("Columns:", self.cs_columns_spin)
 
         self.cs_padding_spin = NoWheelSpinBox()
         self.cs_padding_spin.setRange(0, 100)
-        self.cs_padding_spin.setValue(4)
+        self.cs_padding_spin.setValue(_CONTACT_SHEET_DEFAULT_PADDING)
         self.cs_padding_spin.setSuffix(" px")
         form_layout.addRow("Padding:", self.cs_padding_spin)
 

--- a/src/renderkit/ui/timeline_controller.py
+++ b/src/renderkit/ui/timeline_controller.py
@@ -9,6 +9,8 @@ from typing import Optional
 from renderkit.core.sequence import FrameSequence
 from renderkit.ui.qt_compat import QLabel, QSlider, QTimer, QWidget
 
+_SCRUB_DEBOUNCE_MS = 40
+
 PreviewLoader = Callable[[Path, bool], None]
 
 
@@ -41,7 +43,7 @@ class TimelineController:
 
         self._timer = QTimer(parent or container)
         self._timer.setSingleShot(True)
-        self._timer.setInterval(40)
+        self._timer.setInterval(_SCRUB_DEBOUNCE_MS)
         self._timer.timeout.connect(self._apply_scrub)
 
         self._slider.valueChanged.connect(self._on_slider_changed)

--- a/src/renderkit/ui/widgets.py
+++ b/src/renderkit/ui/widgets.py
@@ -45,6 +45,13 @@ logger = logging.getLogger(__name__)
 
 _PREVIEW_LABEL_COLOR = "#888"
 _PREVIEW_LABEL_ERROR_COLOR = "#f44336"
+_FULLSCREEN_MIN_WIDTH = 800
+_FULLSCREEN_MIN_HEIGHT = 600
+_ZOOM_FIT_MARGIN = 0.95
+_ZOOM_STEP_FACTOR = 1.15
+_ZOOM_MIN = 0.01
+_ZOOM_MAX = 10.0
+_COPY_BTN_RESET_DELAY_MS = 2000
 _QT_ALIGN_CENTER = qt_enum("AlignmentFlag", "AlignCenter")
 _QT_KEEP_ASPECT_RATIO = qt_enum("AspectRatioMode", "KeepAspectRatio")
 _QT_SMOOTH_TRANSFORMATION = qt_enum("TransformationMode", "SmoothTransformation")
@@ -229,7 +236,7 @@ class FullscreenPreviewWindow(QWidget):
         """
         super().__init__()
         self.setWindowTitle(title)
-        self.setMinimumSize(800, 600)
+        self.setMinimumSize(_FULLSCREEN_MIN_WIDTH, _FULLSCREEN_MIN_HEIGHT)
         self._pixmap = pixmap
         self._zoom_factor = 1.0  # 1.0 = Original size
         self._is_panning = False
@@ -301,11 +308,11 @@ class FullscreenPreviewWindow(QWidget):
 
         viewport_size = self.scroll_area.viewport().size()
         if viewport_size.width() <= 0 or viewport_size.height() <= 0:
-            viewport_size = QSize(800, 600)
+            viewport_size = QSize(_FULLSCREEN_MIN_WIDTH, _FULLSCREEN_MIN_HEIGHT)
 
         w_scale = viewport_size.width() / self._pixmap.width()
         h_scale = viewport_size.height() / self._pixmap.height()
-        self._zoom_factor = min(w_scale, h_scale) * 0.95  # Leave a small margin
+        self._zoom_factor = min(w_scale, h_scale) * _ZOOM_FIT_MARGIN
         self._update_image()
 
     def _update_image(self) -> None:
@@ -343,14 +350,13 @@ class FullscreenPreviewWindow(QWidget):
         # Zoom to mouse logic
         old_zoom = self._zoom_factor
         angle = event.angleDelta().y()
-        zoom_step = 1.15
         if angle > 0:
-            self._zoom_factor *= zoom_step
+            self._zoom_factor *= _ZOOM_STEP_FACTOR
         else:
-            self._zoom_factor /= zoom_step
+            self._zoom_factor /= _ZOOM_STEP_FACTOR
 
         # Clamp zoom: 1% to 1000%
-        self._zoom_factor = max(0.01, min(self._zoom_factor, 10.0))
+        self._zoom_factor = max(_ZOOM_MIN, min(self._zoom_factor, _ZOOM_MAX))
 
         # Update image
         self._update_image()
@@ -412,7 +418,7 @@ class FullscreenPreviewWindow(QWidget):
         """Copy current pixmap to clipboard."""
         QApplication.clipboard().setPixmap(self._pixmap)
         self.copy_btn.setText("Copied!")
-        QTimer.singleShot(2000, lambda: self.copy_btn.setText("Copy Image"))
+        QTimer.singleShot(_COPY_BTN_RESET_DELAY_MS, lambda: self.copy_btn.setText("Copy Image"))
 
 
 class PreviewWidget(QWidget):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from renderkit.core import converter as converter_module
-from renderkit.core.config import ConversionConfig, ConversionConfigBuilder
+from renderkit.core.config import ContactSheetConfig, ConversionConfig, ConversionConfigBuilder
 from renderkit.core.converter import SequenceConverter
 from renderkit.exceptions import (
     ColorSpaceError,
@@ -15,6 +15,7 @@ from renderkit.exceptions import (
     VideoEncodingError,
 )
 from renderkit.io.file_info import FileInfo
+from renderkit.processing.contact_sheet import compute_contact_sheet_label_metrics
 from renderkit.processing.video_encoder import VideoEncoder
 
 
@@ -184,6 +185,35 @@ class _FakeBuf:
 class _PassThroughColorConverter:
     def convert_buf(self, buf, input_space=None):
         return buf
+
+
+class TestSequenceConverterLayout:
+    """Tests for converter output layout calculations."""
+
+    def test_contact_sheet_resolution_uses_shared_label_metrics(self) -> None:
+        """Contact sheet output dimensions should match renderer label metrics."""
+        cs_config = ContactSheetConfig(
+            columns=2,
+            thumbnail_width=40,
+            padding=5,
+            show_labels=True,
+            font_size=8,
+        )
+        converter = SequenceConverter.__new__(SequenceConverter)
+        converter.config = ConversionConfig(
+            input_pattern="render.%04d.exr",
+            output_path="output.mp4",
+            contact_sheet_mode=True,
+            contact_sheet_config=cs_config,
+        )
+        converter.contact_sheet_generator = object()
+        file_info = FileInfo(width=100, height=50, channels=3, layers=["beauty", "diffuse", "z"])
+
+        output_width, output_height = converter._resolve_output_resolution(file_info, 100, 50)
+
+        _, label_h = compute_contact_sheet_label_metrics(cs_config)
+        assert output_width == (40 + (5 * 2)) * 2
+        assert output_height == (20 + (5 * 2) + label_h) * 2
 
 
 class TestSequenceConverterFailures:


### PR DESCRIPTION
## Summary
- centralize contact-sheet label metrics and use them in converter + CLI sizing paths
- extract module-local constants for UI timing/layout, burn-in placement, FFmpeg/logging policy, and replacement audit naming
- add a regression test to keep converter contact-sheet resolution aligned with renderer label metrics

## Why
Gemini flagged a set of magic literals. Most were maintainability-only, but the contact-sheet label height estimate had drifted from the renderer formula, which could make converter output sizing inconsistent with actual contact-sheet rendering.

## Validation
- `uv --native-tls run --extra dev ruff check src tests`
- `uv --native-tls run --extra dev pytest tests/test_contact_sheet.py tests/test_converter.py tests/test_cli.py tests/test_ui_logic_preview.py tests/test_main_window_settings.py tests/test_logging_utils.py tests/test_sequence_replacement.py tests/test_video_encoder.py`
- `uv --native-tls run --extra dev pytest` before hook formatting: 176 passed, 9 skipped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralized hardcoded configuration values into module-level constants across rendering and UI systems for improved code maintainability and consistency.
  * Extracted contact sheet label metrics into a shared helper function to ensure consistent label sizing calculations.
  * Improved FFmpeg environment variable handling with dedicated constants.

* **Tests**
  * Added integration test to verify consistent contact sheet label metric calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->