### PR TITLE
Fix versioned numeric sequence detection

### DIFF
--- a/src/renderkit/core/sequence.py
+++ b/src/renderkit/core/sequence.py
@@ -139,8 +139,9 @@ class SequenceDetector:
 
         # Check for numeric pattern (e.g., render.0001.exr)
         else:
-            numeric_match = re.search(r"(\d+)", filename)
-            if numeric_match:
+            numeric_matches = list(re.finditer(r"(\d+)", filename))
+            if numeric_matches:
+                numeric_match = numeric_matches[-1]
                 # Try to find sequence by replacing the number
                 frame_numbers = SequenceDetector._find_frames_by_numeric_pattern(
                     base_path, filename, numeric_match

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -86,6 +86,18 @@ class TestSequenceDetector:
         assert len(sequence) == 5
         assert sequence.frame_numbers == [1, 2, 3, 4, 5]
 
+    def test_detect_numeric_pattern_uses_last_digit_group(self, tmp_path: Path) -> None:
+        """Test numeric detection uses frame digits, not version digits."""
+        for i in range(1, 4):
+            (tmp_path / f"shot_v001.{i:04d}.exr").touch()
+
+        pattern = str(tmp_path / "shot_v001.0001.exr")
+        sequence = SequenceDetector.detect_sequence(pattern)
+
+        assert sequence.pattern == "shot_v001.%04d.exr"
+        assert sequence.frame_numbers == [1, 2, 3]
+        assert sequence.get_file_path(3) == tmp_path / "shot_v001.0003.exr"
+
     def test_detect_sequence_not_found(self, tmp_path: Path) -> None:
         """Test error when sequence cannot be detected."""
         pattern = str(tmp_path / "nonexistent.%04d.exr")


### PR DESCRIPTION
## Summary
- detect the last numeric group in direct numeric filenames so version digits are not treated as frame numbers
- add a regression test for names like `shot_v001.0001.exr`

Closes #94

## Verification
- `uv run --extra dev python -m pytest tests/test_sequence.py -q`
- `uv run --extra dev ruff check src/renderkit/core/sequence.py tests/test_sequence.py`
- `uv run --extra dev ruff format --check src/renderkit/core/sequence.py tests/test_sequence.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sequence detection for filenames with multiple number groups, so the last numeric group is used when identifying frame sequences.
  * Fixed frame pattern detection for files like `shot_v001.0001.exr`, helping the app correctly recognize and resolve numbered frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->