### PR TITLE
[codex] Fix numeric sequence candidate selection

### DIFF
--- a/src/renderkit/core/sequence.py
+++ b/src/renderkit/core/sequence.py
@@ -139,12 +139,12 @@ class SequenceDetector:
 
         # Check for numeric pattern (e.g., render.0001.exr)
         else:
-            numeric_match = re.search(r"(\d+)", filename)
-            if numeric_match:
-                # Try to find sequence by replacing the number
-                frame_numbers = SequenceDetector._find_frames_by_numeric_pattern(
-                    base_path, filename, numeric_match
-                )
+            numeric_matches = list(re.finditer(r"(\d+)", filename))
+            numeric_candidate = SequenceDetector._find_best_numeric_sequence_candidate(
+                base_path, filename, numeric_matches
+            )
+            if numeric_candidate:
+                numeric_match, frame_numbers = numeric_candidate
                 if frame_numbers:
                     padding = len(numeric_match.group(1))
                     start_pos, end_pos = numeric_match.span()
@@ -198,6 +198,39 @@ class SequenceDetector:
                             continue
 
         return sorted(frame_numbers)
+
+    @staticmethod
+    def _find_best_numeric_sequence_candidate(
+        base_path: Path, filename: str, numeric_matches: list[re.Match[str]]
+    ) -> Optional[tuple[re.Match[str], list[int]]]:
+        """Find the numeric group most likely to be the frame number.
+
+        Args:
+            base_path: Directory to search
+            filename: Filename with one or more numeric groups
+            numeric_matches: Regex matches for numeric groups in the filename
+
+        Returns:
+            Best numeric match and its detected frame numbers, or None
+        """
+        candidates: list[tuple[re.Match[str], list[int]]] = []
+        for numeric_match in numeric_matches:
+            frame_numbers = SequenceDetector._find_frames_by_numeric_pattern(
+                base_path, filename, numeric_match
+            )
+            if frame_numbers:
+                candidates.append((numeric_match, frame_numbers))
+
+        if not candidates:
+            return None
+
+        return max(
+            candidates,
+            key=lambda candidate: (
+                len(candidate[1]),
+                candidate[0].start(),
+            ),
+        )
 
     @staticmethod
     def _find_frames_by_numeric_pattern(

--- a/src/renderkit/core/sequence.py
+++ b/src/renderkit/core/sequence.py
@@ -139,12 +139,13 @@ class SequenceDetector:
 
         # Check for numeric pattern (e.g., render.0001.exr)
         else:
-            numeric_matches = list(re.finditer(r"(\d+)", filename))
-            numeric_candidate = SequenceDetector._find_best_numeric_sequence_candidate(
-                base_path, filename, numeric_matches
-            )
-            if numeric_candidate:
-                numeric_match, frame_numbers = numeric_candidate
+            numeric_matches = list(re.finditer(r"(?<=\.)(\d{3,5})(?=\.)", filename))
+            if numeric_matches:
+                numeric_match = numeric_matches[-1]
+                # Try to find sequence by replacing the frame-like number.
+                frame_numbers = SequenceDetector._find_frames_by_numeric_pattern(
+                    base_path, filename, numeric_match
+                )
                 if frame_numbers:
                     padding = len(numeric_match.group(1))
                     start_pos, end_pos = numeric_match.span()
@@ -198,39 +199,6 @@ class SequenceDetector:
                             continue
 
         return sorted(frame_numbers)
-
-    @staticmethod
-    def _find_best_numeric_sequence_candidate(
-        base_path: Path, filename: str, numeric_matches: list[re.Match[str]]
-    ) -> Optional[tuple[re.Match[str], list[int]]]:
-        """Find the numeric group most likely to be the frame number.
-
-        Args:
-            base_path: Directory to search
-            filename: Filename with one or more numeric groups
-            numeric_matches: Regex matches for numeric groups in the filename
-
-        Returns:
-            Best numeric match and its detected frame numbers, or None
-        """
-        candidates: list[tuple[re.Match[str], list[int]]] = []
-        for numeric_match in numeric_matches:
-            frame_numbers = SequenceDetector._find_frames_by_numeric_pattern(
-                base_path, filename, numeric_match
-            )
-            if frame_numbers:
-                candidates.append((numeric_match, frame_numbers))
-
-        if not candidates:
-            return None
-
-        return max(
-            candidates,
-            key=lambda candidate: (
-                len(candidate[1]),
-                candidate[0].start(),
-            ),
-        )
 
     @staticmethod
     def _find_frames_by_numeric_pattern(

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -110,6 +110,39 @@ class TestSequenceDetector:
         assert sequence.frame_numbers == [1, 2, 3]
         assert sequence.get_file_path(3) == tmp_path / "render.0003.layer1.exr"
 
+    def test_detect_numeric_pattern_ignores_more_common_suffix_digits(self, tmp_path: Path) -> None:
+        """Test numeric detection does not prefer non-frame suffix variants."""
+        for i in range(1, 3):
+            (tmp_path / f"render.{i:04d}.layer1.exr").touch()
+        for i in range(2, 8):
+            (tmp_path / f"render.0001.layer{i}.exr").touch()
+
+        pattern = str(tmp_path / "render.0001.layer1.exr")
+        sequence = SequenceDetector.detect_sequence(pattern)
+
+        assert sequence.pattern == "render.%04d.layer1.exr"
+        assert sequence.frame_numbers == [1, 2]
+
+    def test_detect_numeric_pattern_ignores_version_variants(self, tmp_path: Path) -> None:
+        """Test numeric detection does not treat version digits as frames."""
+        for i in range(1, 6):
+            (tmp_path / f"shot001_v{i:03d}.0001.exr").touch()
+
+        pattern = str(tmp_path / "shot001_v001.0001.exr")
+        sequence = SequenceDetector.detect_sequence(pattern)
+
+        assert sequence.pattern == "shot001_v001.%04d.exr"
+        assert sequence.frame_numbers == [1]
+
+    def test_detect_numeric_pattern_requires_three_to_five_digits(self, tmp_path: Path) -> None:
+        """Test direct numeric detection ignores oversized numeric runs."""
+        (tmp_path / "shot.000001.exr").touch()
+
+        pattern = str(tmp_path / "shot.000001.exr")
+
+        with pytest.raises(SequenceDetectionError):
+            SequenceDetector.detect_sequence(pattern)
+
     def test_detect_sequence_not_found(self, tmp_path: Path) -> None:
         """Test error when sequence cannot be detected."""
         pattern = str(tmp_path / "nonexistent.%04d.exr")
@@ -160,13 +193,13 @@ class TestSequenceDetector:
     def test_numeric_pattern_get_file_path_uses_detected_padding(self, tmp_path: Path) -> None:
         """Test numeric sequence detection stores a reusable pattern."""
         for i in range(1, 4):
-            (tmp_path / f"shot.{i:06d}.exr").touch()
+            (tmp_path / f"shot.{i:05d}.exr").touch()
 
-        pattern = str(tmp_path / "shot.000001.exr")
+        pattern = str(tmp_path / "shot.00001.exr")
         sequence = SequenceDetector.detect_sequence(pattern)
 
-        assert sequence.pattern == "shot.%06d.exr"
-        assert sequence.get_file_path(3) == tmp_path / "shot.000003.exr"
+        assert sequence.pattern == "shot.%05d.exr"
+        assert sequence.get_file_path(3) == tmp_path / "shot.00003.exr"
 
     def test_auto_detect_fps_logs_metadata_read_failures(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -86,6 +86,30 @@ class TestSequenceDetector:
         assert len(sequence) == 5
         assert sequence.frame_numbers == [1, 2, 3, 4, 5]
 
+    def test_detect_numeric_pattern_uses_varying_digits_after_version(self, tmp_path: Path) -> None:
+        """Test numeric detection uses frame digits, not version digits."""
+        for i in range(1, 4):
+            (tmp_path / f"shot_v001.{i:04d}.exr").touch()
+
+        pattern = str(tmp_path / "shot_v001.0001.exr")
+        sequence = SequenceDetector.detect_sequence(pattern)
+
+        assert sequence.pattern == "shot_v001.%04d.exr"
+        assert sequence.frame_numbers == [1, 2, 3]
+        assert sequence.get_file_path(3) == tmp_path / "shot_v001.0003.exr"
+
+    def test_detect_numeric_pattern_ignores_fixed_numeric_suffix(self, tmp_path: Path) -> None:
+        """Test numeric detection ignores later fixed numeric tags."""
+        for i in range(1, 4):
+            (tmp_path / f"render.{i:04d}.layer1.exr").touch()
+
+        pattern = str(tmp_path / "render.0001.layer1.exr")
+        sequence = SequenceDetector.detect_sequence(pattern)
+
+        assert sequence.pattern == "render.%04d.layer1.exr"
+        assert sequence.frame_numbers == [1, 2, 3]
+        assert sequence.get_file_path(3) == tmp_path / "render.0003.layer1.exr"
+
     def test_detect_sequence_not_found(self, tmp_path: Path) -> None:
         """Test error when sequence cannot be detected."""
         pattern = str(tmp_path / "nonexistent.%04d.exr")


### PR DESCRIPTION
## Summary
- choose direct numeric frame tokens only from dot-delimited 3-5 digit groups
- preserve versioned filename support like `shot_v001.0001.exr`
- avoid treating fixed numeric suffixes like `layer1`, `2k`, versions, or shot IDs as frame numbers

## Root cause
Direct numeric detection used to grab the first digit group, while PR #113 tried always using the last digit group. Both are too broad for production filenames with shot IDs, versions, resolution tags, or layer tags.

This keeps the fallback intentionally narrow: direct numeric filenames are treated as frame sequences only when the candidate token looks like `.<3-5 digits>.`, and the last such token is used as the frame number.

## Verification
- `uv --system-certs run --extra dev python -m pytest tests/test_sequence.py -q`
- `uv --system-certs run --extra dev ruff check src/renderkit/core/sequence.py tests/test_sequence.py`
- `uv --system-certs run --extra dev ruff format --check src/renderkit/core/sequence.py tests/test_sequence.py`
- `uv --system-certs run --extra dev python -m pytest -q`

Fixes #94